### PR TITLE
Added the possibility to change the ARB path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Dart package that creates a binding between your translations from .arb files and your Flutter app. It generates boilerplate code for official Dart Intl library and adds auto-complete for keys in Dart code.
 
-Follow us on [Twitter](https://twitter.com/localizely 'Follow us on Twitter').
+Follow us on [Twitter](https://twitter.com/localizely "Follow us on Twitter").
 
 ## Usage
 
@@ -34,7 +34,7 @@ flutter_intl:
 ### Add ARB files
 
 Add one ARB file for each locale you need to support in your Flutter app.
-Add them to `lib/l10n` folder inside your project, and name them in a following way: `intl_<LOCALE_ISO_CODE>.arb`.
+Add them to `lib/l10n` folder inside your project, and name them in a following way: `intl_<LOCALE_ISO_CODE>.arb`.  
 For example: `intl_en.arb` or `intl_en_GB.arb`.
 You can also change the ARB folder from `lib/l10n` to a custom directory by adding the `arb_path` line in your `pubspec.yaml` file.
 
@@ -62,7 +62,7 @@ This will upload your main ARB file to Localizely. Check out the 'Configure pack
 
 This will download all available ARB files from the Localizely platform and put them under `lib/l10n` folder, if you did not give a different `arb-path`, inside your project.
 
-Notes: 
-Argument `project-id` can be omitted if `pubspec.yaml` file contains `project_id` configuration under `flutter_intl/localizely` section.
-Argument `api-token` can be omitted if `~/.localizely/credentials.yaml` file contains `api_token` configuration.
-Optional argument `arb-path` is `lib/l10n` as default and needs only to be set, if you want to place your ARB files in a custom directory.
+Notes:  
+Argument `project-id` can be omitted if `pubspec.yaml` file contains `project_id` configuration under `flutter_intl/localizely` section.  
+Argument `api-token` can be omitted if `~/.localizely/credentials.yaml` file contains `api_token` configuration.  
+Optional argument `arb-path` has the value `lib/l10n` as default and needs only to be set, if you want to place your ARB files in a custom directory.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ flutter_intl:
   <b>enabled: true</b> # Required. Must be set to true to activate the package. Default: false
   class_name: S # Optional. Sets the name for the generated localization class. Default: S
   main_locale: en # Optional. Sets the main locale used for generating localization files. Provided value should consist of language code and optional script and country codes separated with underscore (e.g. 'en', 'en_GB', 'zh_Hans', 'zh_Hans_CN'). Default: en
+  arb_path: lib/l10n # Optional. Sets the path to the arb resource files. Provided value should be a valid path (e.g. 'lib', 'res/', 'assets\l10n').
 
   localizely: # Optional settings if you use Localizely platform. Read more: https://localizely.com/flutter-localization-workflow
     project_id: # Get it from the https://app.localizely.com/projects page.

--- a/README.md
+++ b/README.md
@@ -51,17 +51,17 @@ This will produce files inside `lib/generated` directory.
 
 #### Upload main ARB file
 
-      flutter pub run intl_utils:localizely_upload_main --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb_dir <ARB_DIR>]
+      flutter pub run intl_utils:localizely_upload_main --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb-dir <ARB_DIR>]
 
 This will upload your main ARB file to Localizely. Check out the 'Configure package' section for additional upload configuration.
 
 #### Download ARB files
 
-      flutter pub run intl_utils:localizely_download --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb_dir <ARB_DIR>]
+      flutter pub run intl_utils:localizely_download --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb-dir <ARB_DIR>]
 
-This will download all available ARB files from the Localizely platform and put them under `lib/l10n` folder, if you did not give a different `arb-path`, inside your project.
+This will download all available ARB files from the Localizely platform and put them under `lib/l10n` folder, if you did not give a different `arb-dir`, inside your project.
 
 Notes:  
 Argument `project-id` can be omitted if `pubspec.yaml` file contains `project_id` configuration under `flutter_intl/localizely` section.  
 Argument `api-token` can be omitted if `~/.localizely/credentials.yaml` file contains `api_token` configuration.  
-Optional argument `arb_dir` has the value `lib/l10n` as default and needs only to be set, if you want to place your ARB files in a custom directory.
+Optional argument `arb-dir` has the value `lib/l10n` as default and needs only to be set, if you want to place your ARB files in a custom directory.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ flutter_intl:
   <b>enabled: true</b> # Required. Must be set to true to activate the package. Default: false
   class_name: S # Optional. Sets the name for the generated localization class. Default: S
   main_locale: en # Optional. Sets the main locale used for generating localization files. Provided value should consist of language code and optional script and country codes separated with underscore (e.g. 'en', 'en_GB', 'zh_Hans', 'zh_Hans_CN'). Default: en
-  arb_path: lib/l10n # Optional. Sets the path to the ARB resource files. Provided value should be a valid path on your system (e.g. 'lib', 'res/', 'assets\l10n').
-
+  arb_dir: lib/l10n # Optional. Sets the directory of your ARB resource files. Provided value should be a valid path on your system.
   localizely: # Optional settings if you use Localizely platform. Read more: https://localizely.com/flutter-localization-workflow
     project_id: # Get it from the https://app.localizely.com/projects page.
     branch: # Get it from the “Branches” page on the Localizely platform, in case branching is enabled and you want to use a non-main branch.
@@ -36,7 +35,7 @@ flutter_intl:
 Add one ARB file for each locale you need to support in your Flutter app.
 Add them to `lib/l10n` folder inside your project, and name them in a following way: `intl_<LOCALE_ISO_CODE>.arb`.  
 For example: `intl_en.arb` or `intl_en_GB.arb`.
-You can also change the ARB folder from `lib/l10n` to a custom directory by adding the `arb_path` line in your `pubspec.yaml` file.
+You can also change the ARB folder from `lib/l10n` to a custom directory by adding the `arb_dir` line in your `pubspec.yaml` file.
 
 If you wonder how to format key-values content inside ARB files, [here](https://github.com/google/app-resource-bundle/wiki/ApplicationResourceBundleSpecification) is detailed explanation.
 
@@ -52,17 +51,17 @@ This will produce files inside `lib/generated` directory.
 
 #### Upload main ARB file
 
-      flutter pub run intl_utils:localizely_upload_main --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb-path <ARB_PATH>]
+      flutter pub run intl_utils:localizely_upload_main --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb_dir <ARB_PATH>]
 
 This will upload your main ARB file to Localizely. Check out the 'Configure package' section for additional upload configuration.
 
 #### Download ARB files
 
-      flutter pub run intl_utils:localizely_download --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb-path <ARB_PATH>]
+      flutter pub run intl_utils:localizely_download --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb_dir <ARB_PATH>]
 
 This will download all available ARB files from the Localizely platform and put them under `lib/l10n` folder, if you did not give a different `arb-path`, inside your project.
 
 Notes:  
 Argument `project-id` can be omitted if `pubspec.yaml` file contains `project_id` configuration under `flutter_intl/localizely` section.  
 Argument `api-token` can be omitted if `~/.localizely/credentials.yaml` file contains `api_token` configuration.  
-Optional argument `arb-path` has the value `lib/l10n` as default and needs only to be set, if you want to place your ARB files in a custom directory.
+Optional argument `arb_dir` has the value `lib/l10n` as default and needs only to be set, if you want to place your ARB files in a custom directory.

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ This will produce files inside `lib/generated` directory.
 
 #### Upload main ARB file
 
-      flutter pub run intl_utils:localizely_upload_main --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb_dir <ARB_PATH>]
+      flutter pub run intl_utils:localizely_upload_main --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb_dir <ARB_DIR>]
 
 This will upload your main ARB file to Localizely. Check out the 'Configure package' section for additional upload configuration.
 
 #### Download ARB files
 
-      flutter pub run intl_utils:localizely_download --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb_dir <ARB_PATH>]
+      flutter pub run intl_utils:localizely_download --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb_dir <ARB_DIR>]
 
 This will download all available ARB files from the Localizely platform and put them under `lib/l10n` folder, if you did not give a different `arb-path`, inside your project.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ flutter_intl:
   <b>enabled: true</b> # Required. Must be set to true to activate the package. Default: false
   class_name: S # Optional. Sets the name for the generated localization class. Default: S
   main_locale: en # Optional. Sets the main locale used for generating localization files. Provided value should consist of language code and optional script and country codes separated with underscore (e.g. 'en', 'en_GB', 'zh_Hans', 'zh_Hans_CN'). Default: en
-  arb_path: lib/l10n # Optional. Sets the path to the arb resource files. Provided value should be a valid path (e.g. 'lib', 'res/', 'assets\l10n').
+  arb_path: lib/l10n # Optional. Sets the path to the ARB resource files. Provided value should be a valid path on your system (e.g. 'lib', 'res/', 'assets\l10n').
 
   localizely: # Optional settings if you use Localizely platform. Read more: https://localizely.com/flutter-localization-workflow
     project_id: # Get it from the https://app.localizely.com/projects page.
@@ -36,6 +36,7 @@ flutter_intl:
 Add one ARB file for each locale you need to support in your Flutter app.
 Add them to `lib/l10n` folder inside your project, and name them in a following way: `intl_<LOCALE_ISO_CODE>.arb`.
 For example: `intl_en.arb` or `intl_en_GB.arb`.
+You can also change the ARB folder from `lib/l10n` to a custom directory by adding the `arb_path` line in your `pubspec.yaml` file.
 
 If you wonder how to format key-values content inside ARB files, [here](https://github.com/google/app-resource-bundle/wiki/ApplicationResourceBundleSpecification) is detailed explanation.
 
@@ -51,16 +52,17 @@ This will produce files inside `lib/generated` directory.
 
 #### Upload main ARB file
 
-      flutter pub run intl_utils:localizely_upload_main --project-id <PROJECT_ID> --api-token <API_TOKEN>
+      flutter pub run intl_utils:localizely_upload_main --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb-path <ARB_PATH>]
 
 This will upload your main ARB file to Localizely. Check out the 'Configure package' section for additional upload configuration.
 
 #### Download ARB files
 
-      flutter pub run intl_utils:localizely_download --project-id <PROJECT_ID> --api-token <API_TOKEN>
+      flutter pub run intl_utils:localizely_download --project-id <PROJECT_ID> --api-token <API_TOKEN> [--arb-path <ARB_PATH>]
 
-This will download all available ARB files from the Localizely platform and put them under `lib/l10n` folder inside your project.
+This will download all available ARB files from the Localizely platform and put them under `lib/l10n` folder, if you did not give a different `arb-path`, inside your project.
 
 Notes: 
 Argument `project-id` can be omitted if `pubspec.yaml` file contains `project_id` configuration under `flutter_intl/localizely` section.
-Argument `api-token` can be omitted if `~/.localizely/credentials.yaml` file contains `api_token` configuration.  
+Argument `api-token` can be omitted if `~/.localizely/credentials.yaml` file contains `api_token` configuration.
+Optional argument `arb-path` is `lib/l10n` as default and needs only to be set, if you want to place your ARB files in a custom directory.

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -1,8 +1,8 @@
 library intl_utils;
 
 import 'package:intl_utils/intl_utils.dart';
-import 'package:intl_utils/src/utils/utils.dart';
 import 'package:intl_utils/src/generator/generator_exception.dart';
+import 'package:intl_utils/src/utils/utils.dart';
 
 Future<void> main(List<String> args) async {
   try {

--- a/bin/localizely_download.dart
+++ b/bin/localizely_download.dart
@@ -3,15 +3,16 @@ library intl_utils;
 import 'dart:io';
 
 import 'package:args/args.dart' as args;
-
-import 'package:intl_utils/src/config/pubspec_config.dart';
-import 'package:intl_utils/src/config/credentials_config.dart';
 import 'package:intl_utils/src/config/config_exception.dart';
+import 'package:intl_utils/src/config/credentials_config.dart';
+import 'package:intl_utils/src/config/pubspec_config.dart';
 import 'package:intl_utils/src/localizely/api/api_exception.dart';
 import 'package:intl_utils/src/localizely/service/service.dart';
 import 'package:intl_utils/src/localizely/service/service_exception.dart';
-import 'package:intl_utils/src/utils/utils.dart';
 import 'package:intl_utils/src/utils/file_utils.dart';
+import 'package:intl_utils/src/utils/utils.dart';
+
+import '../lib/src/constants/constants.dart';
 
 Future<void> main(List<String> arguments) async {
   final argParser = args.ArgParser();
@@ -30,6 +31,11 @@ Future<void> main(List<String> arguments) async {
     'api-token',
     help: 'Localizely API token.',
   );
+  argParser.addOption(
+    'arb-path',
+    help: 'Path of the arb files.',
+    defaultsTo: defaultArbPath,
+  );
 
   try {
     final argResults = argParser.parse(arguments);
@@ -40,6 +46,7 @@ Future<void> main(List<String> arguments) async {
 
     var projectId = argResults['project-id'] as String;
     var apiToken = argResults['api-token'] as String;
+    var arbPath = argResults['arb-path'] as String;
 
     if (projectId == null) {
       var pubspecConfig = PubspecConfig();
@@ -61,7 +68,7 @@ Future<void> main(List<String> arguments) async {
       }
     }
 
-    await LocalizelyService.download(projectId, apiToken);
+    await LocalizelyService.download(projectId, apiToken, arbPath);
   } on args.ArgParserException catch (e) {
     exitWithError('${e.message}\n\n${argParser.usage}');
   } on ConfigException catch (e) {

--- a/bin/localizely_download.dart
+++ b/bin/localizely_download.dart
@@ -45,7 +45,7 @@ Future<void> main(List<String> arguments) async {
 
     var projectId = argResults['project-id'] as String;
     var apiToken = argResults['api-token'] as String;
-    var arbPath = argResults['arb-path'] as String;
+    var arbDir = argResults['arb-dir'] as String;
 
     if (projectId == null) {
       var pubspecConfig = PubspecConfig();
@@ -67,7 +67,12 @@ Future<void> main(List<String> arguments) async {
       }
     }
 
-    await LocalizelyService.download(projectId, apiToken, arbPath);
+    if (arbDir == null) {
+      var pubspecConfig = PubspecConfig();
+      arbDir = pubspecConfig.arbDir ?? defaultArbDir;
+    }
+
+    await LocalizelyService.download(projectId, apiToken, arbDir);
   } on args.ArgParserException catch (e) {
     exitWithError('${e.message}\n\n${argParser.usage}');
   } on ConfigException catch (e) {

--- a/bin/localizely_download.dart
+++ b/bin/localizely_download.dart
@@ -31,9 +31,9 @@ Future<void> main(List<String> arguments) async {
     help: 'Localizely API token.',
   );
   argParser.addOption(
-    'arb-path',
-    help: 'Path of the arb files.',
-    defaultsTo: defaultArbPath,
+    'arb-dir',
+    help: 'Directory of the arb files.',
+    defaultsTo: defaultArbDir,
   );
 
   try {

--- a/bin/localizely_download.dart
+++ b/bin/localizely_download.dart
@@ -33,7 +33,6 @@ Future<void> main(List<String> arguments) async {
   argParser.addOption(
     'arb-dir',
     help: 'Directory of the arb files.',
-    defaultsTo: defaultArbDir,
   );
 
   try {

--- a/bin/localizely_download.dart
+++ b/bin/localizely_download.dart
@@ -6,13 +6,12 @@ import 'package:args/args.dart' as args;
 import 'package:intl_utils/src/config/config_exception.dart';
 import 'package:intl_utils/src/config/credentials_config.dart';
 import 'package:intl_utils/src/config/pubspec_config.dart';
+import 'package:intl_utils/src/constants/constants.dart';
 import 'package:intl_utils/src/localizely/api/api_exception.dart';
 import 'package:intl_utils/src/localizely/service/service.dart';
 import 'package:intl_utils/src/localizely/service/service_exception.dart';
 import 'package:intl_utils/src/utils/file_utils.dart';
 import 'package:intl_utils/src/utils/utils.dart';
-
-import '../lib/src/constants/constants.dart';
 
 Future<void> main(List<String> arguments) async {
   final argParser = args.ArgParser();

--- a/bin/localizely_upload_main.dart
+++ b/bin/localizely_upload_main.dart
@@ -3,15 +3,16 @@ library intl_utils;
 import 'dart:io';
 
 import 'package:args/args.dart' as args;
-
-import 'package:intl_utils/src/config/pubspec_config.dart';
-import 'package:intl_utils/src/config/credentials_config.dart';
 import 'package:intl_utils/src/config/config_exception.dart';
+import 'package:intl_utils/src/config/credentials_config.dart';
+import 'package:intl_utils/src/config/pubspec_config.dart';
 import 'package:intl_utils/src/localizely/api/api_exception.dart';
 import 'package:intl_utils/src/localizely/service/service.dart';
 import 'package:intl_utils/src/localizely/service/service_exception.dart';
-import 'package:intl_utils/src/utils/utils.dart';
 import 'package:intl_utils/src/utils/file_utils.dart';
+import 'package:intl_utils/src/utils/utils.dart';
+
+import '../lib/src/constants/constants.dart';
 
 Future<void> main(List<String> arguments) async {
   final argParser = args.ArgParser();
@@ -30,6 +31,11 @@ Future<void> main(List<String> arguments) async {
     'api-token',
     help: 'Localizely API token.',
   );
+  argParser.addOption(
+    'arb-path',
+    help: 'Path of the arb files.',
+    defaultsTo: defaultArbPath,
+  );
 
   try {
     final argResults = argParser.parse(arguments);
@@ -40,6 +46,7 @@ Future<void> main(List<String> arguments) async {
 
     var projectId = argResults['project-id'] as String;
     var apiToken = argResults['api-token'] as String;
+    var arbPath = argResults['arb-path'] as String;
 
     if (projectId == null) {
       var pubspecConfig = PubspecConfig();
@@ -61,7 +68,7 @@ Future<void> main(List<String> arguments) async {
       }
     }
 
-    await LocalizelyService.uploadMainArbFile(projectId, apiToken);
+    await LocalizelyService.uploadMainArbFile(projectId, apiToken, arbPath);
   } on args.ArgParserException catch (e) {
     exitWithError('${e.message}\n\n${argParser.usage}');
   } on ConfigException catch (e) {

--- a/bin/localizely_upload_main.dart
+++ b/bin/localizely_upload_main.dart
@@ -31,9 +31,9 @@ Future<void> main(List<String> arguments) async {
     help: 'Localizely API token.',
   );
   argParser.addOption(
-    'arb-path',
+    'arb-dir',
     help: 'Path of the arb files.',
-    defaultsTo: defaultArbPath,
+    defaultsTo: defaultArbDir,
   );
 
   try {
@@ -45,7 +45,7 @@ Future<void> main(List<String> arguments) async {
 
     var projectId = argResults['project-id'] as String;
     var apiToken = argResults['api-token'] as String;
-    var arbPath = argResults['arb-path'] as String;
+    var arbDir = argResults['arb-dir'] as String;
 
     if (projectId == null) {
       var pubspecConfig = PubspecConfig();
@@ -67,7 +67,7 @@ Future<void> main(List<String> arguments) async {
       }
     }
 
-    await LocalizelyService.uploadMainArbFile(projectId, apiToken, arbPath);
+    await LocalizelyService.uploadMainArbFile(projectId, apiToken, arbDir);
   } on args.ArgParserException catch (e) {
     exitWithError('${e.message}\n\n${argParser.usage}');
   } on ConfigException catch (e) {

--- a/bin/localizely_upload_main.dart
+++ b/bin/localizely_upload_main.dart
@@ -32,8 +32,7 @@ Future<void> main(List<String> arguments) async {
   );
   argParser.addOption(
     'arb-dir',
-    help: 'Path of the arb files.',
-    defaultsTo: defaultArbDir,
+    help: 'Directory of the arb files.',
   );
 
   try {
@@ -65,6 +64,11 @@ Future<void> main(List<String> arguments) async {
         throw ConfigException(
             "Argument 'api-token' was not provided, nor 'api_token' config was set within the '${getLocalizelyCredentialsFilePath()}' file.");
       }
+    }
+
+    if (arbDir == null) {
+      var pubspecConfig = PubspecConfig();
+      arbDir = pubspecConfig.arbDir ?? defaultArbDir;
     }
 
     await LocalizelyService.uploadMainArbFile(projectId, apiToken, arbDir);

--- a/bin/localizely_upload_main.dart
+++ b/bin/localizely_upload_main.dart
@@ -6,13 +6,12 @@ import 'package:args/args.dart' as args;
 import 'package:intl_utils/src/config/config_exception.dart';
 import 'package:intl_utils/src/config/credentials_config.dart';
 import 'package:intl_utils/src/config/pubspec_config.dart';
+import 'package:intl_utils/src/constants/constants.dart';
 import 'package:intl_utils/src/localizely/api/api_exception.dart';
 import 'package:intl_utils/src/localizely/service/service.dart';
 import 'package:intl_utils/src/localizely/service/service_exception.dart';
 import 'package:intl_utils/src/utils/file_utils.dart';
 import 'package:intl_utils/src/utils/utils.dart';
-
-import '../lib/src/constants/constants.dart';
 
 Future<void> main(List<String> arguments) async {
   final argParser = args.ArgParser();

--- a/lib/src/config/pubspec_config.dart
+++ b/lib/src/config/pubspec_config.dart
@@ -7,7 +7,7 @@ class PubspecConfig {
   bool _enabled;
   String _className;
   String _mainLocale;
-  String _arbPath;
+  String _arbDir;
   LocalizelyConfig _localizelyConfig;
 
   PubspecConfig() {
@@ -33,8 +33,8 @@ class PubspecConfig {
     _mainLocale = flutterIntlConfig['main_locale'] is String
         ? flutterIntlConfig['main_locale']
         : null;
-    _arbPath = flutterIntlConfig['arb_path'] is String
-        ? flutterIntlConfig['arb_path']
+    _arbDir = flutterIntlConfig['arb_dir'] is String
+        ? flutterIntlConfig['arb_dir']
         : null;
     _localizelyConfig =
         LocalizelyConfig.fromConfig(flutterIntlConfig['localizely']);
@@ -46,7 +46,7 @@ class PubspecConfig {
 
   String get mainLocale => _mainLocale;
 
-  String get arbPath => _arbPath;
+  String get arbDir => _arbDir;
 
   LocalizelyConfig get localizelyConfig => _localizelyConfig;
 }

--- a/lib/src/config/pubspec_config.dart
+++ b/lib/src/config/pubspec_config.dart
@@ -1,12 +1,13 @@
 import 'package:yaml/yaml.dart' as yaml;
 
-import 'config_exception.dart';
 import '../utils/file_utils.dart';
+import 'config_exception.dart';
 
 class PubspecConfig {
   bool _enabled;
   String _className;
   String _mainLocale;
+  String _arbPath;
   LocalizelyConfig _localizelyConfig;
 
   PubspecConfig() {
@@ -32,6 +33,9 @@ class PubspecConfig {
     _mainLocale = flutterIntlConfig['main_locale'] is String
         ? flutterIntlConfig['main_locale']
         : null;
+    _arbPath = flutterIntlConfig['arb_path'] is String
+        ? flutterIntlConfig['arb_path']
+        : null;
     _localizelyConfig =
         LocalizelyConfig.fromConfig(flutterIntlConfig['localizely']);
   }
@@ -41,6 +45,8 @@ class PubspecConfig {
   String get className => _className;
 
   String get mainLocale => _mainLocale;
+
+  String get arbPath => _arbPath;
 
   LocalizelyConfig get localizelyConfig => _localizelyConfig;
 }

--- a/lib/src/constants/constants.dart
+++ b/lib/src/constants/constants.dart
@@ -1,5 +1,8 @@
+import 'package:path/path.dart';
+
 const defaultClassName = 'S';
 const defaultMainLocale = 'en';
+final defaultArbPath = join('lib', 'l10n');
 const defaultUploadOverwrite = false;
 const defaultUploadAsReviewed = false;
 const defaultOtaEnabled = false;

--- a/lib/src/constants/constants.dart
+++ b/lib/src/constants/constants.dart
@@ -2,7 +2,7 @@ import 'package:path/path.dart';
 
 const defaultClassName = 'S';
 const defaultMainLocale = 'en';
-final defaultArbPath = join('lib', 'l10n');
+final defaultArbDir = join('lib', 'l10n');
 const defaultUploadOverwrite = false;
 const defaultUploadAsReviewed = false;
 const defaultOtaEnabled = false;

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -1,17 +1,18 @@
 import 'dart:convert';
 
+import '../config/pubspec_config.dart';
+import '../constants/constants.dart';
+import '../utils/file_utils.dart';
+import '../utils/utils.dart';
+import 'generator_exception.dart';
+import 'intl_translation_helper.dart';
 import 'label.dart';
 import 'templates.dart';
-import 'intl_translation_helper.dart';
-import 'generator_exception.dart';
-import '../config/pubspec_config.dart';
-import '../utils/utils.dart';
-import '../utils/file_utils.dart';
-import '../constants/constants.dart';
 
 class Generator {
   String _className;
   String _mainLocale;
+  String _arbPath;
   bool _otaEnabled;
 
   Generator() {
@@ -37,6 +38,16 @@ class Generator {
       }
     }
 
+    _arbPath = defaultArbPath;
+    if (pubspecConfig.arbPath != null) {
+      if (isValidPath(pubspecConfig.arbPath)) {
+        _arbPath = pubspecConfig.arbPath;
+      } else {
+        warning(
+            "Config parameter 'arb_path' requires value consisted of a path (e.g. 'lib', 'res/', 'assets\l10n').");
+      }
+    }
+
     _otaEnabled =
         pubspecConfig.localizelyConfig?.otaEnabled ?? defaultOtaEnabled;
   }
@@ -48,15 +59,15 @@ class Generator {
   }
 
   Future<void> _updateL10nDir() async {
-    var mainArbFile = getArbFileForLocale(_mainLocale);
+    var mainArbFile = getArbFileForLocale(_mainLocale, _arbPath);
     if (mainArbFile == null) {
-      await createArbFileForLocale(_mainLocale);
+      await createArbFileForLocale(_mainLocale, _arbPath);
     }
   }
 
   Future<void> _updateGeneratedDir() async {
     var labels = _getLabelsFromMainArbFile();
-    var locales = _orderLocales(getLocales());
+    var locales = _orderLocales(getLocales(_arbPath));
     var content =
         generateL10nDartFileContent(_className, labels, locales, _otaEnabled);
     await updateL10nDartFile(content);
@@ -70,7 +81,7 @@ class Generator {
   }
 
   List<Label> _getLabelsFromMainArbFile() {
-    var mainArbFile = getArbFileForLocale(_mainLocale);
+    var mainArbFile = getArbFileForLocale(_mainLocale, _arbPath);
     if (mainArbFile == null) {
       throw GeneratorException(
           "Can't find ARB file for the '$_mainLocale' locale.");
@@ -112,7 +123,7 @@ class Generator {
   Future<void> _generateDartFiles() async {
     var outputDir = getIntlDirectoryPath();
     var dartFiles = [getL10nDartFilePath()];
-    var arbFiles = getArbFiles().map((file) => file.path).toList();
+    var arbFiles = getArbFiles(_arbPath).map((file) => file.path).toList();
 
     var helper = IntlTranslationHelper();
     helper.generateFromArb(outputDir, dartFiles, arbFiles);

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -12,7 +12,7 @@ import 'templates.dart';
 class Generator {
   String _className;
   String _mainLocale;
-  String _arbPath;
+  String _arbDir;
   bool _otaEnabled;
 
   Generator() {
@@ -38,13 +38,13 @@ class Generator {
       }
     }
 
-    _arbPath = defaultArbPath;
-    if (pubspecConfig.arbPath != null) {
-      if (isValidPath(pubspecConfig.arbPath)) {
-        _arbPath = pubspecConfig.arbPath;
+    _arbDir = defaultArbDir;
+    if (pubspecConfig.arbDir != null) {
+      if (isValidPath(pubspecConfig.arbDir)) {
+        _arbDir = pubspecConfig.arbDir;
       } else {
         warning(
-            "Config parameter 'arb_path' requires value consisted of a path (e.g. 'lib', 'res/', 'assets\l10n').");
+            "Config parameter 'arb_dir' requires value consisted of a path (e.g. 'lib', 'res/', 'lib\\l10n').");
       }
     }
 
@@ -59,15 +59,15 @@ class Generator {
   }
 
   Future<void> _updateL10nDir() async {
-    var mainArbFile = getArbFileForLocale(_mainLocale, _arbPath);
+    var mainArbFile = getArbFileForLocale(_mainLocale, _arbDir);
     if (mainArbFile == null) {
-      await createArbFileForLocale(_mainLocale, _arbPath);
+      await createArbFileForLocale(_mainLocale, _arbDir);
     }
   }
 
   Future<void> _updateGeneratedDir() async {
     var labels = _getLabelsFromMainArbFile();
-    var locales = _orderLocales(getLocales(_arbPath));
+    var locales = _orderLocales(getLocales(_arbDir));
     var content =
         generateL10nDartFileContent(_className, labels, locales, _otaEnabled);
     await updateL10nDartFile(content);
@@ -81,7 +81,7 @@ class Generator {
   }
 
   List<Label> _getLabelsFromMainArbFile() {
-    var mainArbFile = getArbFileForLocale(_mainLocale, _arbPath);
+    var mainArbFile = getArbFileForLocale(_mainLocale, _arbDir);
     if (mainArbFile == null) {
       throw GeneratorException(
           "Can't find ARB file for the '$_mainLocale' locale.");
@@ -123,7 +123,7 @@ class Generator {
   Future<void> _generateDartFiles() async {
     var outputDir = getIntlDirectoryPath();
     var dartFiles = [getL10nDartFilePath()];
-    var arbFiles = getArbFiles(_arbPath).map((file) => file.path).toList();
+    var arbFiles = getArbFiles(_arbDir).map((file) => file.path).toList();
 
     var helper = IntlTranslationHelper();
     helper.generateFromArb(outputDir, dartFiles, arbFiles);

--- a/lib/src/generator/intl_translation_helper.dart
+++ b/lib/src/generator/intl_translation_helper.dart
@@ -28,15 +28,14 @@
 //     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 //     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import 'dart:io';
 import 'dart:convert';
-
-import 'package:path/path.dart' as path;
+import 'dart:io';
 
 import 'package:intl_translation/extract_messages.dart';
 import 'package:intl_translation/generate_localized.dart';
 import 'package:intl_translation/src/icu_parser.dart';
 import 'package:intl_translation/src/intl_message.dart';
+import 'package:path/path.dart' as path;
 
 import '../utils/utils.dart';
 

--- a/lib/src/generator/label.dart
+++ b/lib/src/generator/label.dart
@@ -10,6 +10,7 @@ enum ContentType { literal, argument, plural, gender, select, unsupported }
 
 class ValidationException implements Exception {
   final String message;
+
   ValidationException([this.message]);
 }
 

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -1,5 +1,5 @@
-import 'label.dart';
 import '../utils/utils.dart';
+import 'label.dart';
 
 String generateL10nDartFileContent(
     String className, List<Label> labels, List<String> locales,

--- a/lib/src/localizely/api/api.dart
+++ b/lib/src/localizely/api/api.dart
@@ -3,9 +3,9 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 
+import '../../utils/utils.dart';
 import '../api/api_exception.dart';
 import '../model/download_response.dart';
-import '../../utils/utils.dart';
 
 class LocalizelyApi {
   static final String _baseUrl = 'https://api.localizely.com';

--- a/lib/src/localizely/model/download_response.dart
+++ b/lib/src/localizely/model/download_response.dart
@@ -1,5 +1,5 @@
-import 'package:http/http.dart';
 import 'package:archive/archive.dart';
+import 'package:http/http.dart';
 
 import 'file_data.dart';
 

--- a/lib/src/localizely/service/service.dart
+++ b/lib/src/localizely/service/service.dart
@@ -1,16 +1,16 @@
-import 'service_exception.dart';
-import '../api/api.dart';
 import '../../config/pubspec_config.dart';
-import '../../utils/file_utils.dart';
 import '../../constants/constants.dart';
+import '../../utils/file_utils.dart';
 import '../../utils/utils.dart';
+import '../api/api.dart';
+import 'service_exception.dart';
 
 class LocalizelyService {
   LocalizelyService._();
 
   /// Uploads main ARB file on Localizely.
   static Future<void> uploadMainArbFile(
-      String projectId, String apiToken) async {
+      String projectId, String apiToken, String arbPath) async {
     var pubspecConfig = PubspecConfig();
 
     var mainLocale = pubspecConfig.mainLocale;
@@ -24,7 +24,7 @@ class LocalizelyService {
       mainLocale = defaultMainLocale;
     }
 
-    var mainArbFile = getArbFileForLocale(mainLocale);
+    var mainArbFile = getArbFileForLocale(mainLocale, arbPath);
     if (mainArbFile == null) {
       throw ServiceException("Can't find ARB file for the main locale.");
     }
@@ -40,7 +40,8 @@ class LocalizelyService {
   }
 
   /// Downloads all ARB files from Localizely.
-  static Future<void> download(String projectId, String apiToken) async {
+  static Future<void> download(
+      String projectId, String apiToken, String arbPath) async {
     var pubspecConfig = PubspecConfig();
 
     var branch = pubspecConfig.localizelyConfig?.branch;
@@ -48,7 +49,7 @@ class LocalizelyService {
     var response = await LocalizelyApi.download(projectId, apiToken, branch);
 
     for (var fileData in response.files) {
-      await updateArbFile(fileData.name, fileData.bytes);
+      await updateArbFile(fileData.name, fileData.bytes, arbPath);
     }
   }
 }

--- a/lib/src/localizely/service/service.dart
+++ b/lib/src/localizely/service/service.dart
@@ -41,7 +41,7 @@ class LocalizelyService {
 
   /// Downloads all ARB files from Localizely.
   static Future<void> download(
-      String projectId, String apiToken, String arbPath) async {
+      String projectId, String apiToken, String arbDir) async {
     var pubspecConfig = PubspecConfig();
 
     var branch = pubspecConfig.localizelyConfig?.branch;
@@ -49,7 +49,7 @@ class LocalizelyService {
     var response = await LocalizelyApi.download(projectId, apiToken, branch);
 
     for (var fileData in response.files) {
-      await updateArbFile(fileData.name, fileData.bytes, arbPath);
+      await updateArbFile(fileData.name, fileData.bytes, arbDir);
     }
   }
 }

--- a/lib/src/parser/icu_parser.dart
+++ b/lib/src/parser/icu_parser.dart
@@ -34,23 +34,37 @@ import 'message_format.dart';
 
 class IcuParser {
   Parser get openCurly => char('{');
+
   Parser get closeCurly => char('}');
+
   Parser get quotedCurly => (string("'{'") | string("'}'")).map((x) => x[1]);
+
   Parser get icuEscapedText => quotedCurly | twoSingleQuotes;
+
   Parser get curly => (openCurly | closeCurly);
+
   Parser get notAllowedInIcuText => curly | char('<');
+
   Parser get icuText => notAllowedInIcuText.neg();
+
   Parser get notAllowedInNormalText => char('{');
+
   Parser get normalText => notAllowedInNormalText.neg();
+
   Parser get messageText => (icuEscapedText | icuText)
       .plus()
       .flatten()
       .map((result) => LiteralElement(result));
+
   Parser get nonIcuMessageText =>
       normalText.plus().flatten().map((result) => LiteralElement(result));
+
   Parser get twoSingleQuotes => string("''").map((x) => "'");
+
   Parser get number => digit().plus().flatten().trim().map(int.parse);
+
   Parser get id => (letter() & (word() | char('_')).star()).flatten().trim();
+
   Parser get comma => char(',').trim();
 
   /// Given a list of possible keywords, return a rule that accepts any of them.
@@ -60,6 +74,7 @@ class IcuParser {
 
   Parser get pluralKeyword => asKeywords(
       ['=0', '=1', '=2', 'zero', 'one', 'two', 'few', 'many', 'other']);
+
   Parser get genderKeyword => asKeywords(['female', 'male', 'other']);
 
   var interiorText = undefined();
@@ -67,6 +82,7 @@ class IcuParser {
   Parser get preface => (openCurly & id & comma).map((values) => values[1]);
 
   Parser get pluralLiteral => string('plural');
+
   Parser get pluralClause => (pluralKeyword &
           openCurly &
           interiorText &
@@ -74,12 +90,15 @@ class IcuParser {
       .trim()
       .map((result) => Option(result[0],
           List<BaseElement>.from(result[2] is List ? result[2] : [result[2]])));
+
   Parser get plural =>
       preface & pluralLiteral & comma & pluralClause.plus() & closeCurly;
+
   Parser get intlPlural => plural
       .map((result) => PluralElement(result[0], List<Option>.from(result[3])));
 
   Parser get selectLiteral => string('select');
+
   Parser get genderClause => (genderKeyword &
           openCurly &
           interiorText &
@@ -87,23 +106,30 @@ class IcuParser {
       .trim()
       .map((result) => Option(result[0],
           List<BaseElement>.from(result[2] is List ? result[2] : [result[2]])));
+
   Parser get gender =>
       preface & selectLiteral & comma & genderClause.plus() & closeCurly;
+
   Parser get intlGender => gender
       .map((result) => GenderElement(result[0], List<Option>.from(result[3])));
+
   Parser get selectClause => (id & openCurly & interiorText & closeCurly)
       .trim()
       .map((result) => Option(result[0],
           List<BaseElement>.from(result[2] is List ? result[2] : [result[2]])));
+
   Parser get generalSelect =>
       preface & selectLiteral & comma & selectClause.plus() & closeCurly;
+
   Parser get intlSelect => generalSelect
       .map((result) => SelectElement(result[0], List<Option>.from(result[3])));
 
   Parser get pluralOrGenderOrSelect => (intlPlural | intlGender | intlSelect);
 
   Parser get contents => pluralOrGenderOrSelect | parameter | messageText;
+
   Parser get simpleText => (nonIcuMessageText | parameter | openCurly).plus();
+
   Parser get empty => epsilon().map((_) => LiteralElement(''));
 
   Parser get parameter =>

--- a/lib/src/utils/file_utils.dart
+++ b/lib/src/utils/file_utils.dart
@@ -21,10 +21,10 @@ File getPubspecFile() {
 }
 
 /// Gets arb file for the given locale.
-File getArbFileForLocale(String locale, String arbPath) {
+File getArbFileForLocale(String locale, String arbDir) {
   var rootDirPath = getRootDirectoryPath();
-  var arbFilePath = path.join(rootDirPath, arbPath, 'intl_$locale.arb');
-  var arbFile = File(arbFilePath);
+  var arbFileDir = path.join(rootDirPath, arbDir, 'intl_$locale.arb');
+  var arbFile = File(arbFileDir);
 
   return arbFile.existsSync() ? arbFile : null;
 }
@@ -32,8 +32,8 @@ File getArbFileForLocale(String locale, String arbPath) {
 /// Creates arb file for the given locale.
 Future<File> createArbFileForLocale(String locale, String arbPath) async {
   var rootDirPath = getRootDirectoryPath();
-  var arbFilePath = path.join(rootDirPath, arbPath, 'intl_$locale.arb');
-  var arbFile = File(arbFilePath);
+  var arbFileDir = path.join(rootDirPath, arbPath, 'intl_$locale.arb');
+  var arbFile = File(arbFileDir);
 
   await arbFile.create(recursive: true);
   await arbFile.writeAsString('{}');

--- a/lib/src/utils/file_utils.dart
+++ b/lib/src/utils/file_utils.dart
@@ -21,18 +21,18 @@ File getPubspecFile() {
 }
 
 /// Gets arb file for the given locale.
-File getArbFileForLocale(String locale) {
+File getArbFileForLocale(String locale, String arbPath) {
   var rootDirPath = getRootDirectoryPath();
-  var arbFilePath = path.join(rootDirPath, 'lib', 'l10n', 'intl_$locale.arb');
+  var arbFilePath = path.join(rootDirPath, arbPath, 'intl_$locale.arb');
   var arbFile = File(arbFilePath);
 
   return arbFile.existsSync() ? arbFile : null;
 }
 
 /// Creates arb file for the given locale.
-Future<File> createArbFileForLocale(String locale) async {
+Future<File> createArbFileForLocale(String locale, String arbPath) async {
   var rootDirPath = getRootDirectoryPath();
-  var arbFilePath = path.join(rootDirPath, 'lib', 'l10n', 'intl_$locale.arb');
+  var arbFilePath = path.join(rootDirPath, arbPath, 'intl_$locale.arb');
   var arbFile = File(arbFilePath);
 
   await arbFile.create(recursive: true);
@@ -42,8 +42,8 @@ Future<File> createArbFileForLocale(String locale) async {
 }
 
 /// Gets all arb files in the project.
-List<FileSystemEntity> getArbFiles() {
-  var l10nDirPath = path.join(getRootDirectoryPath(), 'lib', 'l10n');
+List<FileSystemEntity> getArbFiles(String arbPath) {
+  var l10nDirPath = path.join(getRootDirectoryPath(), arbPath);
   var arbFiles = Directory(l10nDirPath)
       .listSync()
       .where((file) =>
@@ -58,8 +58,8 @@ List<FileSystemEntity> getArbFiles() {
 }
 
 /// Gets all locales in the project.
-List<String> getLocales() {
-  var locales = getArbFiles()
+List<String> getLocales(String arbPath) {
+  var locales = getArbFiles(arbPath)
       .map((file) => path.basename(file.path))
       .map((fileName) =>
           fileName.substring('intl_'.length, fileName.length - '.arb'.length))
@@ -69,9 +69,10 @@ List<String> getLocales() {
 }
 
 /// Updates arb file content.
-Future<void> updateArbFile(String fileName, Uint8List bytes) async {
+Future<void> updateArbFile(
+    String fileName, Uint8List bytes, String arbPath) async {
   var rootDirPath = getRootDirectoryPath();
-  var arbFilePath = path.join(rootDirPath, 'lib', 'l10n', fileName);
+  var arbFilePath = path.join(rootDirPath, arbPath, fileName);
   var arbFile = File(arbFilePath);
 
   if (!arbFile.existsSync()) {

--- a/lib/src/utils/file_utils.dart
+++ b/lib/src/utils/file_utils.dart
@@ -23,8 +23,8 @@ File getPubspecFile() {
 /// Gets arb file for the given locale.
 File getArbFileForLocale(String locale, String arbDir) {
   var rootDirPath = getRootDirectoryPath();
-  var arbFileDir = path.join(rootDirPath, arbDir, 'intl_$locale.arb');
-  var arbFile = File(arbFileDir);
+  var arbFilePath = path.join(rootDirPath, arbDir, 'intl_$locale.arb');
+  var arbFile = File(arbFilePath);
 
   return arbFile.existsSync() ? arbFile : null;
 }
@@ -32,8 +32,8 @@ File getArbFileForLocale(String locale, String arbDir) {
 /// Creates arb file for the given locale.
 Future<File> createArbFileForLocale(String locale, String arbPath) async {
   var rootDirPath = getRootDirectoryPath();
-  var arbFileDir = path.join(rootDirPath, arbPath, 'intl_$locale.arb');
-  var arbFile = File(arbFileDir);
+  var arbFilePath = path.join(rootDirPath, arbPath, 'intl_$locale.arb');
+  var arbFile = File(arbFilePath);
 
   await arbFile.create(recursive: true);
   await arbFile.writeAsString('{}');

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -1,11 +1,14 @@
-import 'dart:io';
 import 'dart:convert' as convert;
+import 'dart:io';
 
 bool isValidClassName(String value) =>
     RegExp(r'^[A-Z][a-zA-Z0-9]*$').hasMatch(value);
 
 bool isValidLocale(String value) =>
     RegExp(r'^[a-z]{2}(_[A-Z][a-z]{3})?(_[A-Z]{2})?$').hasMatch(value);
+
+bool isValidPath(String value) =>
+    RegExp(r'^(?:[A-Za-z]:)?([\/\\]{0,2}\w*)+$').hasMatch(value);
 
 bool isLangScriptCountryLocale(String locale) =>
     RegExp(r'^[a-z]{2}_[A-Z][a-z]{3}_[A-Z]{2}$').hasMatch(locale);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -112,7 +112,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1"
+    version: "0.12.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -168,14 +168,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.9"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.2.3"
   mime:
     dependency: transitive
     description:
@@ -183,13 +183,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.6+3"
-  multi_server_socket:
-    dependency: transitive
-    description:
-      name: multi_server_socket
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
   node_interop:
     dependency: transitive
     description:
@@ -231,14 +224,14 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.2"
   petitparser:
     dependency: "direct main"
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
   pool:
     dependency: transitive
     description:
@@ -336,21 +329,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.3"
+    version: "1.15.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.18"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.11"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "7.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.8"
+    version: "0.39.17"
   archive:
     dependency: "direct main"
     description:
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -50,13 +50,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.3"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.14.13"
   convert:
     dependency: transitive
     description:
@@ -70,21 +77,21 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.9"
+    version: "0.14.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   csslib:
     dependency: transitive
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.16.2"
   dart_style:
     dependency: transitive
     description:
@@ -154,7 +161,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+1"
+    version: "0.6.2"
   logging:
     dependency: transitive
     description:
@@ -182,7 +189,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+3"
+    version: "0.9.7"
   mockito:
     dependency: "direct dev"
     description:
@@ -190,34 +197,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.1"
-  multi_server_socket:
-    dependency: transitive
-    description:
-      name: multi_server_socket
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
   node_interop:
     dependency: transitive
     description:
       name: node_interop
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.1"
   node_io:
     dependency: transitive
     description:
       name: node_io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.8"
+    version: "1.4.12"
   package_config:
     dependency: transitive
     description:
@@ -266,7 +266,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "0.7.9"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -315,7 +315,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.9.5"
   stream_channel:
     dependency: transitive
     description:
@@ -343,7 +343,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.3"
+    version: "1.15.4"
   test_api:
     dependency: transitive
     description:
@@ -357,21 +357,21 @@ packages:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.11"
+    version: "0.3.11+1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.2.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "4.2.0"
   watcher:
     dependency: transitive
     description:
@@ -392,7 +392,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.3"
+    version: "0.7.3"
   yaml:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
 
 dependencies:
   args: '>=0.12.1 <2.0.0'
-  archive: ^2.0.0
+  archive: ^2.0.13
   intl_translation: 0.17.10
-  http: ^0.12.0
-  path: ^1.6.4
-  petitparser: ^3.0.0
-  yaml: ^2.2.0
+  http: ^0.12.2
+  path: ^1.7.0
+  petitparser: ^3.1.0
+  yaml: ^2.2.1
 
 dev_dependencies:
-  pedantic: ^1.9.0
-  test: ^1.9.4
+  pedantic: ^1.9.2
+  test: ^1.15.3

--- a/test/label_test.dart
+++ b/test/label_test.dart
@@ -1,6 +1,5 @@
-import 'package:test/test.dart';
-
 import 'package:intl_utils/src/generator/label.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Label instantiation', () {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
-
 import 'package:intl_utils/src/parser/icu_parser.dart';
 import 'package:intl_utils/src/parser/message_format.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Literal messages', () {

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -1,8 +1,39 @@
+import 'package:intl_utils/src/utils/utils.dart';
 import 'package:test/test.dart';
 
-import 'package:intl_utils/src/utils/utils.dart';
-
 void main() {
+  group('Path validation', () {
+    test('Test path validation with blank string',
+        () => expect(isValidPath('  '), isFalse));
+
+    test('Test path validation with forbidden path character *',
+        () => expect(isValidPath('te*/lib'), isFalse));
+
+    test('Test path validation with forbidden path character "',
+        () => expect(isValidPath('te"/lib'), isFalse));
+
+    test('Test path validation with forbidden path character ?',
+        () => expect(isValidPath('te?/lib'), isFalse));
+
+    test('Test path validation with empty string',
+        () => expect(isValidPath(''), isTrue));
+
+    test('Test path validation with Windows path',
+        () => expect(isValidPath('lib\l10n'), isTrue));
+
+    test('Test path validation with UNIX path',
+        () => expect(isValidPath('lib/l10n'), isTrue));
+
+    test('Test path validation with escaped path separators',
+        () => expect(isValidPath('lib\\l10n'), isTrue));
+
+    test('Test path validation with dual path separators',
+        () => expect(isValidPath('lib//l10n'), isTrue));
+
+    test('Test path validation with Windows absolute path',
+        () => expect(isValidPath('C:\\dart\\l10n'), isTrue));
+  });
+
   group('Locale validation', () {
     test('Test locale validation with empty string',
         () => expect(isValidLocale(''), isFalse));


### PR DESCRIPTION
I added an optional setting for the yaml file to change the path to the ARB files from `lib/l10n` to a custom path. It should be fully compatible with any previous version and won't affect any project as long as the `arb_path` is not set manually.

To keep it compatible with your service, I also added a optional argument for the localizely download and upload which defaults to the standard folder `lib/l10n`.