### PR TITLE
Improve template to run in null-safe environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the "flutter-intl" extension will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.9.1 – 2021-01
+
+- Make generated code work in null-safe environments by annotating the Dart version
+
 ## 1.9.0 - 2020-10-19
 
 - Make generated directory path configurable
@@ -63,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.3.0 - 2020-04-21
 
-- Support select messages 
+- Support select messages
 
 - Make order of supported locales consistent
 

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -5,6 +5,7 @@ String generateL10nDartFileContent(
     String className, List<Label> labels, List<String> locales,
     [bool otaEnabled = false]) {
   return """
+//@dart=2.9
 // GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';${otaEnabled ? '\n${_generateLocalizelySdkImport()}' : ''}
@@ -21,22 +22,22 @@ import 'intl/messages_all.dart';
 
 class $className {
   $className();
-  
+
   static $className current;
-  
+
   static const AppLocalizationDelegate delegate =
     AppLocalizationDelegate();
 
   static Future<$className> load(Locale locale) {
     final name = (locale.countryCode?.isEmpty ?? false) ? locale.languageCode : locale.toString();
-    final localeName = Intl.canonicalizedLocale(name);${otaEnabled ? '\n${_generateMetadataSetter()}' : ''} 
+    final localeName = Intl.canonicalizedLocale(name);${otaEnabled ? '\n${_generateMetadataSetter()}' : ''}
     return initializeMessages(localeName).then((_) {
       Intl.defaultLocale = localeName;
       $className.current = $className();
-      
+
       return $className.current;
     });
-  } 
+  }
 
   static $className of(BuildContext context) {
     return Localizations.of<$className>(context, $className);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intl_utils
 description: intl_utils is a dart library that generates Dart localization code from ARB file. Generated code relies on Intl library.
-version: 1.9.0
+version: 1.9.1
 homepage: https://github.com/localizely/intl_utils
 
 environment:


### PR DESCRIPTION
This realses my suggestion [here](https://github.com/localizely/intl_utils/issues/14#issuecomment-753451062)

Annotating the generated source files with a dart version string allows using the generated code in migrated contexts.

This is a quick fix until a proper null_safe version comes along.

**Unfortunately for this to work overall the `intl_translation` package needs an update too.**

You could either go with an dependency overwrite or wait for this to be merged: https://github.com/dart-lang/intl_translation/pull/125

I already use this now. Unfortunately the VSCode extension does not respect the setup in the `pubspec.yaml` file.