### PR TITLE
Replace AppLocalizationDelegate by ${className}Delegate

### DIFF
--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -45,8 +45,8 @@ ${otaEnabled ? '\n${_generateMetadata(labels)}\n' : ''}
 ${labels.map((label) => label.generateDartGetter()).join("\n\n")}
 }
 
-class ${$className}Delegate extends LocalizationsDelegate<$className> {
-  const ${$className}Delegate();
+class ${className}Delegate extends LocalizationsDelegate<$className> {
+  const ${className}Delegate();
 
   List<Locale> get supportedLocales {
     return const <Locale>[
@@ -59,7 +59,7 @@ ${locales.map((locale) => _generateLocale(locale)).join("\n")}
   @override
   Future<$className> load(Locale locale) => $className.load(locale);
   @override
-  bool shouldReload(${$className}Delegate old) => false;
+  bool shouldReload(${className}Delegate old) => false;
 
   bool _isSupported(Locale locale) {
     if (locale != null) {

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -24,8 +24,8 @@ class $className {
   
   static $className current;
   
-  static const AppLocalizationDelegate delegate =
-    AppLocalizationDelegate();
+  static const ${className}Delegate delegate =
+    ${className}Delegate();
 
   static Future<$className> load(Locale locale) {
     final name = (locale.countryCode?.isEmpty ?? false) ? locale.languageCode : locale.toString();

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -45,8 +45,8 @@ ${otaEnabled ? '\n${_generateMetadata(labels)}\n' : ''}
 ${labels.map((label) => label.generateDartGetter()).join("\n\n")}
 }
 
-class AppLocalizationDelegate extends LocalizationsDelegate<$className> {
-  const AppLocalizationDelegate();
+class ${$className}Delegate extends LocalizationsDelegate<$className> {
+  const ${$className}Delegate();
 
   List<Locale> get supportedLocales {
     return const <Locale>[
@@ -59,7 +59,7 @@ ${locales.map((locale) => _generateLocale(locale)).join("\n")}
   @override
   Future<$className> load(Locale locale) => $className.load(locale);
   @override
-  bool shouldReload(AppLocalizationDelegate old) => false;
+  bool shouldReload(${$className}Delegate old) => false;
 
   bool _isSupported(Locale locale) {
     if (locale != null) {


### PR DESCRIPTION
I use this package to generate two difference class name localization.
Delegate will conflict because class naming is AppLocalizationsDelegate same.