### PR TITLE
Detect Dart SDK and generate non null safe code if version is below 2.12

### DIFF
--- a/lib/src/generator/intl_translation_helper.dart
+++ b/lib/src/generator/intl_translation_helper.dart
@@ -52,10 +52,14 @@ class IntlTranslationHelper {
   final Map<String, List<MainMessage>> messages =
       {}; // Track of all processed messages, keyed by message name
 
-  IntlTranslationHelper([bool useDeferredLoading = false]) {
+  IntlTranslationHelper({
+    bool useDeferredLoading = false,
+    bool nnbd = true,
+  }) {
     extraction.suppressWarnings = true;
     generation.useDeferredLoading = useDeferredLoading;
     generation.generatedFilePrefix = '';
+    generation.nnbd = nnbd;
   }
 
   void generateFromArb(

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -2,8 +2,12 @@ import '../utils/utils.dart';
 import 'label.dart';
 
 String generateL10nDartFileContent(
-    String className, List<Label> labels, List<String> locales,
-    [bool otaEnabled = false]) {
+  String className,
+  List<Label> labels,
+  List<String> locales, {
+  bool otaEnabled = false,
+  bool nnbd = true,
+}) {
   return """
 // GENERATED CODE - DO NOT MODIFY BY HAND
 import 'package:flutter/material.dart';
@@ -22,7 +26,7 @@ import 'intl/messages_all.dart';
 class $className {
   $className();
   
-  static $className? current;
+  static ${genNullableTypeStr(className, nnbd: nnbd)} current;
   
   static const AppLocalizationDelegate delegate =
     AppLocalizationDelegate();
@@ -34,11 +38,11 @@ class $className {
       Intl.defaultLocale = localeName;
       $className.current = $className();
       
-      return $className.current!;
+      return $className.current${genBang(nnbd: nnbd)};
     });
   } 
 
-  static $className? of(BuildContext context) {
+  static ${genNullableTypeStr(className, nnbd: nnbd)} of(BuildContext context) {
     return Localizations.of<$className>(context, $className);
   }
 ${otaEnabled ? '\n${_generateMetadata(labels)}\n' : ''}
@@ -62,6 +66,7 @@ ${locales.map((locale) => _generateLocale(locale)).join("\n")}
   bool shouldReload(AppLocalizationDelegate old) => false;
 
   bool _isSupported(Locale locale) {
+    ${nnbd ? '' : 'if (locale == null) return false;'}
     for (var supportedLocale in supportedLocales) {
       if (supportedLocale.languageCode == locale.languageCode) {
         return true;

--- a/lib/src/intl_translation/generate_localized.dart
+++ b/lib/src/intl_translation/generate_localized.dart
@@ -46,6 +46,7 @@
 library generate_localized;
 
 import 'package:intl/intl.dart';
+import 'package:intl_utils/src/utils/utils.dart';
 import 'dart:convert';
 import 'dart:io';
 import 'package:path/path.dart' as path;
@@ -79,6 +80,9 @@ class MessageGeneration {
 
   /// Should we use deferred loading for the generated libraries.
   bool useDeferredLoading = true;
+
+  /// Should we use generate null safe code.
+  bool nnbd = true;
 
   /// The mode to generate in - either 'release' or 'debug'.
   ///
@@ -259,7 +263,8 @@ class MessageLookup extends MessageLookupByLibrary {
       output.write(loadOperation);
     }
     output.write('};\n');
-    output.write('\nMessageLookupByLibrary? _findExact(String localeName) {\n'
+    output.write(
+        '\n${genNullableTypeStr('MessageLookupByLibrary', nnbd: nnbd)} _findExact(String localeName) {\n'
         '  switch (localeName) {\n');
     for (var rawLocale in allLocales) {
       var locale = Intl.canonicalizedLocale(rawLocale);
@@ -322,7 +327,7 @@ bool _messagesExistFor(String locale) {
   }
 }
 
-MessageLookupByLibrary? _findGeneratedMessagesFor(String locale) {
+${genNullableTypeStr('MessageLookupByLibrary', nnbd: nnbd)} _findGeneratedMessagesFor(String locale) {
   var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
       onFailure: (_) => null);
   if (actualLocale == null) return null;

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -38,3 +38,17 @@ String formatJsonMessage(String jsonMessage) {
   var decoded = convert.jsonDecode(jsonMessage);
   return convert.jsonEncode(decoded);
 }
+
+/// Returns the type with the nullable operation if null safe
+String genNullableTypeStr(String type, {required bool nnbd}) {
+  if (nnbd) {
+    return '$type?';
+  } else {
+    return type;
+  }
+}
+
+/// Returns the bang operator if null safe
+String genBang({required bool nnbd}) {
+  return nnbd ? '!' : '';
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -324,7 +324,7 @@ packages:
     source: hosted
     version: "1.5.0"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   intl: ^0.17.0
   path: ^1.8.0
   petitparser: ^4.0.0
+  pub_semver: ^2.0.0
   yaml: ^3.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Fixes: #29 

By using the official package `pub_semver`, we can parse the `sdk` constraint in the pubspec.yaml file and generate the files accordingly.