### PR TITLE
Improve Singleton Initialisation (#35)

### DIFF
--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -25,7 +25,7 @@ class $className {
   static $className? _current;
 
   static $className get current {
-    assert(_current != null, 'No instance of $className was loaded. Try to initialize the $className delegate before accessing $className.current.');
+    if(_current == null) _current = $className();
     return _current!;
   }
 


### PR DESCRIPTION
[As addressed previously in the issue](https://github.com/localizely/intl_utils/issues/35), my guess is that this bug was introduced after `null-safety` migration. And this is fairly isolate case when one can reproduce this. 

Very minor change was made toward retrieval of the singleton.
Tested locally - works well.


Happy to make any amendments if needed.

Cheers

