### PR TITLE
Allow inline plural, gender and select expressions in messages

### DIFF
--- a/lib/src/generator/label.dart
+++ b/lib/src/generator/label.dart
@@ -434,15 +434,18 @@ class Label {
               }
             case ElementType.plural:
               {
-                return MapEntry(index, '\${${_generatePluralMessage(item as PluralElement)}}');
+                return MapEntry(index,
+                    '\${${_generatePluralMessage(item as PluralElement)}}');
               }
             case ElementType.gender:
-            {
-              return MapEntry(index, '\${${_generateGenderMessage(item as GenderElement)}}');
-            }
+              {
+                return MapEntry(index,
+                    '\${${_generateGenderMessage(item as GenderElement)}}');
+              }
             case ElementType.select:
               {
-                return MapEntry(index, '\${${_generateSelectMessage(item as SelectElement)}}');
+                return MapEntry(index,
+                    '\${${_generateSelectMessage(item as SelectElement)}}');
               }
             default:
               {
@@ -729,7 +732,8 @@ class Label {
     var options = <String>[];
 
     _sanitizeSelectOptions(element.options).forEach((option) {
-      options.add("'${option.name}': '${_generatePluralOrSelectOptionMessage(option)}'");
+      options.add(
+          "'${option.name}': '${_generatePluralOrSelectOptionMessage(option)}'");
     });
 
     return 'Intl.select(${element.value}, {${options.join(', ')}})';

--- a/lib/src/intl_translation/src/icu_parser.dart
+++ b/lib/src/intl_translation/src/icu_parser.dart
@@ -118,8 +118,7 @@ class IcuParser {
 
   /// The primary entry point for parsing. Accepts a string and produces
   /// a parsed representation of it as a Message.
-  Parser get message => interiorText
-      .map((chunk) => Message.from(chunk, null));
+  Parser get message => interiorText.map((chunk) => Message.from(chunk, null));
 
   /// Represents an ordinary message, i.e. not a plural/gender/select, although
   /// it may have parameters.

--- a/lib/src/intl_translation/src/icu_parser.dart
+++ b/lib/src/intl_translation/src/icu_parser.dart
@@ -118,7 +118,7 @@ class IcuParser {
 
   /// The primary entry point for parsing. Accepts a string and produces
   /// a parsed representation of it as a Message.
-  Parser get message => (pluralOrGenderOrSelect | empty)
+  Parser get message => interiorText
       .map((chunk) => Message.from(chunk, null));
 
   /// Represents an ordinary message, i.e. not a plural/gender/select, although

--- a/lib/src/parser/icu_parser.dart
+++ b/lib/src/parser/icu_parser.dart
@@ -136,7 +136,7 @@ class IcuParser {
       (openCurly & id & closeCurly).map((result) => ArgumentElement(result[1]));
 
   List<BaseElement>? parse(String message) {
-    var parsed = (pluralOrGenderOrSelect | simpleText | empty)
+    var parsed = interiorText
         .map((result) =>
             List<BaseElement>.from(result is List ? result : [result]))
         .parse(message);

--- a/test/label_test.dart
+++ b/test/label_test.dart
@@ -113,39 +113,83 @@ void main() {
           equals("  // skipped getter for the 'page.home.title' key"));
     });
 
-    // Note: check parser impl.
+    // Note: the generated message may differ from the one in the `messages_<locale>.dart` file
     test('Test dart getter when content has an empty placeholder', () {
       var label = Label('labelName', 'Content {} with empty placeholder');
 
-      expect(label.generateDartGetter(),
-          equals("  // skipped getter for the 'labelName' key"));
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `Content {} with empty placeholder`',
+            '  String get labelName {',
+            '    return Intl.message(',
+            '      \'Content {} with empty placeholder\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [],',
+            '    );',
+            '  }'
+          ].join('\n')));
     });
 
-    // Note: check parser impl.
+    // Note: the generated message may differ from the one in the `messages_<locale>.dart` file
     test('Test dart getter when content has digit placeholder', () {
       var label = Label('labelName', 'Content {0} with digit placeholder');
 
-      expect(label.generateDartGetter(),
-          equals("  // skipped getter for the 'labelName' key"));
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `Content {0} with digit placeholder`',
+            '  String get labelName {',
+            '    return Intl.message(',
+            '      \'Content {0} with digit placeholder\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [],',
+            '    );',
+            '  }'
+          ].join('\n')));
     });
 
-    // Note: check parser impl.
+    // Note: the generated message may differ from the one in the `messages_<locale>.dart` file
     test('Test dart getter when content has hash placeholder', () {
       var label = Label('labelName', 'Content {#} with hash placeholder');
 
-      expect(label.generateDartGetter(),
-          equals("  // skipped getter for the 'labelName' key"));
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `Content {#} with hash placeholder`',
+            '  String get labelName {',
+            '    return Intl.message(',
+            '      \'Content {#} with hash placeholder\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [],',
+            '    );',
+            '  }'
+          ].join('\n')));
     });
 
-    // Note: check parser impl.
+    // Note: the generated message may differ from the one in the `messages_<locale>.dart` file
     test(
         'Test dart getter when content has placeholder which name does not follow naming convention',
         () {
       var label = Label('labelName',
           'Content {invalid-placeholder-name} with invalid placeholder name');
 
-      expect(label.generateDartGetter(),
-          equals("  // skipped getter for the 'labelName' key"));
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `Content {invalid-placeholder-name} with invalid placeholder name`',
+            '  String get labelName {',
+            '    return Intl.message(',
+            '      \'Content {invalid-placeholder-name} with invalid placeholder name\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [],',
+            '    );',
+            '  }'
+          ].join('\n')));
     });
   });
 
@@ -1436,8 +1480,19 @@ void main() {
       var label = Label('labelName',
           '{count, plural, one {one message} unsupportedPluralForm {unsupported plural form message} other {other message}}');
 
-      expect(label.generateDartGetter(),
-          equals("  // skipped getter for the 'labelName' key"));
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `{count, plural, one {one message} unsupportedPluralForm {unsupported plural form message} other {other message}}`',
+            '  String get labelName {',
+            '    return Intl.message(',
+            '      \'{count, plural, one {one message} unsupportedPluralForm {unsupported plural form message} other {other message}}\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [],',
+            '    );',
+            '  }'
+          ].join('\n')));
     });
 
     test(
@@ -2463,6 +2518,200 @@ void main() {
     });
   });
 
+  group('Compound getters', () {
+    test(
+        'Test compound message of literal and plural dart getter with name and content set',
+        () {
+      var label = Label('labelName',
+          'John has {count, plural, one {{count} apple} other {{count} apples}}.');
+
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `John has {count, plural, one {{count} apple} other {{count} apples}}.`',
+            '  String labelName(num count) {',
+            '    return Intl.message(',
+            '      \'John has \${Intl.plural(count, one: \'\$count apple\', other: \'\$count apples\')}.\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [count],',
+            '    );',
+            '  }'
+          ].join('\n')));
+    });
+
+    test(
+        'Test compound message of literal and plural dart getter with name, content and placeholders set',
+        () {
+      var label = Label('labelName',
+          'John has {count, plural, one {{count} apple} other {{count} apples}}.',
+          placeholders: ['count']);
+
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `John has {count, plural, one {{count} apple} other {{count} apples}}.`',
+            '  String labelName(num count) {',
+            '    return Intl.message(',
+            '      \'John has \${Intl.plural(count, one: \'\$count apple\', other: \'\$count apples\')}.\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [count],',
+            '    );',
+            '  }'
+          ].join('\n')));
+    });
+
+    test(
+        'Test compound message of literal and gender dart getter with name and content set',
+        () {
+      var label = Label('labelName',
+          'Welcome {gender, select, male {Mr {name}} female {Mrs {name}} other {dear {name}}}.');
+
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `Welcome {gender, select, male {Mr {name}} female {Mrs {name}} other {dear {name}}}.`',
+            '  String labelName(String gender, Object name) {',
+            '    return Intl.message(',
+            '      \'Welcome \${Intl.gender(gender, male: \'Mr \$name\', female: \'Mrs \$name\', other: \'dear \$name\')}.\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [gender, name],',
+            '    );',
+            '  }'
+          ].join('\n')));
+    });
+
+    test(
+        'Test compound message of literal and gender dart getter with name, content and placeholders set',
+        () {
+      var label = Label('labelName',
+          'Welcome {gender, select, male {Mr {name}} female {Mrs {name}} other {dear {name}}}.',
+          placeholders: ['gender', 'name']);
+
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `Welcome {gender, select, male {Mr {name}} female {Mrs {name}} other {dear {name}}}.`',
+            '  String labelName(String gender, Object name) {',
+            '    return Intl.message(',
+            '      \'Welcome \${Intl.gender(gender, male: \'Mr \$name\', female: \'Mrs \$name\', other: \'dear \$name\')}.\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [gender, name],',
+            '    );',
+            '  }'
+          ].join('\n')));
+    });
+
+    test(
+        'Test compound message of literal and select dart getter with name and content set',
+        () {
+      var label = Label('labelName',
+          'The {choice, select, admin {admin {name}} owner {owner {name}} other {user {name}}}.');
+
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `The {choice, select, admin {admin {name}} owner {owner {name}} other {user {name}}}.`',
+            '  String labelName(Object choice, Object name) {',
+            '    return Intl.message(',
+            '      \'The \${Intl.select(choice, {\'admin\': \'admin \$name\', \'owner\': \'owner \$name\', \'other\': \'user \$name\'})}.\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [choice, name],',
+            '    );',
+            '  }'
+          ].join('\n')));
+    });
+
+    test(
+        'Test compound message of literal and select dart getter with name, content and placeholders set',
+        () {
+      var label = Label('labelName',
+          'The {choice, select, admin {admin {name}} owner {owner {name}} other {user {name}}}.',
+          placeholders: ['choice', 'name']);
+
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `The {choice, select, admin {admin {name}} owner {owner {name}} other {user {name}}}.`',
+            '  String labelName(Object choice, Object name) {',
+            '    return Intl.message(',
+            '      \'The \${Intl.select(choice, {\'admin\': \'admin \$name\', \'owner\': \'owner \$name\', \'other\': \'user \$name\'})}.\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [choice, name],',
+            '    );',
+            '  }'
+          ].join('\n')));
+    });
+
+    test(
+        'Test compound message of argument and plural dart getter with name and content set',
+        () {
+      var label = Label('labelName',
+          '{name} has {count, plural, one {{count} apple} other {{count} apples}} in the bag.');
+
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `{name} has {count, plural, one {{count} apple} other {{count} apples}} in the bag.`',
+            '  String labelName(Object name, num count) {',
+            '    return Intl.message(',
+            '      \'\$name has \${Intl.plural(count, one: \'\$count apple\', other: \'\$count apples\')} in the bag.\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [name, count],',
+            '    );',
+            '  }'
+          ].join('\n')));
+    });
+
+    test(
+        'Test compound message of argument and gender dart getter with name and content set',
+        () {
+      var label = Label('labelName',
+          'The {gender, select, male {Mr {name}} female {Mrs {name}} other {dear {name}}} has the {device}.');
+
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `The {gender, select, male {Mr {name}} female {Mrs {name}} other {dear {name}}} has the {device}.`',
+            '  String labelName(String gender, Object name, Object device) {',
+            '    return Intl.message(',
+            '      \'The \${Intl.gender(gender, male: \'Mr \$name\', female: \'Mrs \$name\', other: \'dear \$name\')} has the \$device.\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [gender, name, device],',
+            '    );',
+            '  }'
+          ].join('\n')));
+    });
+
+    test(
+        'Test compound message of argument and select dart getter with name and content set',
+        () {
+      var label = Label('labelName',
+          'The one {choice, select, coffee {{name} coffee} tea {{name} tea} other {{name} drink}} please for the {client}.');
+
+      expect(
+          label.generateDartGetter(),
+          equals([
+            '  /// `The one {choice, select, coffee {{name} coffee} tea {{name} tea} other {{name} drink}} please for the {client}.`',
+            '  String labelName(Object choice, Object name, Object client) {',
+            '    return Intl.message(',
+            '      \'The one \${Intl.select(choice, {\'coffee\': \'\$name coffee\', \'tea\': \'\$name tea\', \'other\': \'\$name drink\'})} please for the \$client.\',',
+            '      name: \'labelName\',',
+            '      desc: \'\',',
+            '      args: [choice, name, client],',
+            '    );',
+            '  }'
+          ].join('\n')));
+    });
+  });
+
   group('Label metadata', () {
     test('Test label metadata generator when label name is invalid', () {
       var label = Label('Invalid label name', 'Some content');
@@ -2489,7 +2738,29 @@ void main() {
 
       expect(
         label.generateMetadata(),
-        equals('    // skipped metadata for the \'labelName\' key'),
+        equals('    \'labelName\': []'),
+      );
+    });
+
+    test(
+        'Test label metadata generator when label content contains number within curly braces',
+        () {
+      var label = Label('labelName', '{0}');
+
+      expect(
+        label.generateMetadata(),
+        equals('    \'labelName\': []'),
+      );
+    });
+
+    test(
+        'Test label metadata generator when label content contains hash within curly braces',
+        () {
+      var label = Label('labelName', '{#}');
+
+      expect(
+        label.generateMetadata(),
+        equals('    \'labelName\': []'),
       );
     });
 
@@ -2516,13 +2787,61 @@ void main() {
     });
 
     test(
+        'Test label metadata generator when label content contains plural message',
+        () {
+      var label = Label('labelName',
+          '{count, plural, one {{count} item} other {{count} items}}');
+
+      expect(
+        label.generateMetadata(),
+        equals('    \'labelName\': [\'count\']'),
+      );
+    });
+
+    test(
+        'Test label metadata generator when label content contains gender message',
+        () {
+      var label = Label('labelName',
+          '{gender, select, male {Mr {name}} female {Mrs {name}} other {user {name}}}');
+
+      expect(
+        label.generateMetadata(),
+        equals('    \'labelName\': [\'gender\', \'name\']'),
+      );
+    });
+
+    test(
+        'Test label metadata generator when label content contains select message',
+        () {
+      var label = Label('labelName',
+          '{choice, select, admin {admin {name}} owner {owner {name}} other {user {name}}}');
+
+      expect(
+        label.generateMetadata(),
+        equals('    \'labelName\': [\'choice\', \'name\']'),
+      );
+    });
+
+    test(
+        'Test label metadata generator when label content contains compound message',
+        () {
+      var label = Label('labelName',
+          'The {gender, select, male {Mr} female {Mrs} other {user}} {name} has {count, plural, one {{count} apple} other {{count} apples}}.');
+
+      expect(
+        label.generateMetadata(),
+        equals('    \'labelName\': [\'gender\', \'name\', \'count\']'),
+      );
+    });
+
+    test(
         'Test label metadata generator when label content contains invalid placeholder name',
         () {
       var label = Label('labelName', 'Hi {invalie-placeholder}!');
 
       expect(
         label.generateMetadata(),
-        equals('    // skipped metadata for the \'labelName\' key'),
+        equals('    \'labelName\': []'),
       );
     });
 
@@ -2533,7 +2852,7 @@ void main() {
 
       expect(
         label.generateMetadata(),
-        equals('    // skipped metadata for the \'labelName\' key'),
+        equals('    \'labelName\': []'),
       );
     });
   });

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -1174,4 +1174,514 @@ void main() {
       expect(options[2].value[3].value, equals('lastName'));
     });
   });
+
+  group('Compound messages', () {
+    test('Test compound message of literal and plural', () {
+      var response = IcuParser().parse(
+          'John has {count, plural, one {{count} apple} other {{count} apples}}.');
+
+      expect(response?.length, equals(3));
+      expect(response?.elementAt(0).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(0).type, equals(ElementType.literal));
+      expect(response?.elementAt(0).value, equals('John has '));
+
+      expect(response?.elementAt(1).runtimeType, equals(PluralElement));
+      expect(response?.elementAt(1).type, equals(ElementType.plural));
+      expect(response?.elementAt(1).value, equals('count'));
+
+      var options = (response?.elementAt(1) as PluralElement).options;
+
+      expect(options.length, equals(2));
+
+      expect(options[0].name, equals('one'));
+      expect(options[0].value.length, equals(2));
+      expect(options[0].value[0].runtimeType, equals(ArgumentElement));
+      expect(options[0].value[0].type, equals(ElementType.argument));
+      expect(options[0].value[0].value, equals('count'));
+      expect(options[0].value[1].runtimeType, equals(LiteralElement));
+      expect(options[0].value[1].type, equals(ElementType.literal));
+      expect(options[0].value[1].value, equals(' apple'));
+
+      expect(options[1].name, equals('other'));
+      expect(options[1].value.length, equals(2));
+      expect(options[1].value[0].runtimeType, equals(ArgumentElement));
+      expect(options[1].value[0].type, equals(ElementType.argument));
+      expect(options[1].value[0].value, equals('count'));
+      expect(options[1].value[1].runtimeType, equals(LiteralElement));
+      expect(options[1].value[1].type, equals(ElementType.literal));
+      expect(options[1].value[1].value, equals(' apples'));
+
+      expect(response?.elementAt(2).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(2).type, equals(ElementType.literal));
+      expect(response?.elementAt(2).value, equals('.'));
+    });
+
+    test('Test compound message of literal and gender', () {
+      var response = IcuParser().parse(
+          'Welcome {gender, select, male {Mr {name}} female {Mrs {name}} other {dear {name}}}.');
+
+      expect(response?.length, equals(3));
+      expect(response?.elementAt(0).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(0).type, equals(ElementType.literal));
+      expect(response?.elementAt(0).value, equals('Welcome '));
+
+      expect(response?.elementAt(1).runtimeType, equals(GenderElement));
+      expect(response?.elementAt(1).type, equals(ElementType.gender));
+      expect(response?.elementAt(1).value, equals('gender'));
+
+      var options = (response?.elementAt(1) as GenderElement).options;
+
+      expect(options.length, equals(3));
+
+      expect(options[0].name, equals('male'));
+      expect(options[0].value.length, equals(2));
+      expect(options[0].value[0].runtimeType, equals(LiteralElement));
+      expect(options[0].value[0].type, equals(ElementType.literal));
+      expect(options[0].value[0].value, equals('Mr '));
+      expect(options[0].value[1].runtimeType, equals(ArgumentElement));
+      expect(options[0].value[1].type, equals(ElementType.argument));
+      expect(options[0].value[1].value, equals('name'));
+
+      expect(options[1].name, equals('female'));
+      expect(options[1].value.length, equals(2));
+      expect(options[1].value[0].runtimeType, equals(LiteralElement));
+      expect(options[1].value[0].type, equals(ElementType.literal));
+      expect(options[1].value[0].value, equals('Mrs '));
+      expect(options[1].value[1].runtimeType, equals(ArgumentElement));
+      expect(options[1].value[1].type, equals(ElementType.argument));
+      expect(options[1].value[1].value, equals('name'));
+
+      expect(options[2].name, equals('other'));
+      expect(options[2].value.length, equals(2));
+      expect(options[2].value[0].runtimeType, equals(LiteralElement));
+      expect(options[2].value[0].type, equals(ElementType.literal));
+      expect(options[2].value[0].value, equals('dear '));
+      expect(options[2].value[1].runtimeType, equals(ArgumentElement));
+      expect(options[2].value[1].type, equals(ElementType.argument));
+      expect(options[2].value[1].value, equals('name'));
+
+      expect(response?.elementAt(2).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(2).type, equals(ElementType.literal));
+      expect(response?.elementAt(2).value, equals('.'));
+    });
+
+    test('Test compound message of literal and select', () {
+      var response = IcuParser().parse(
+          'The {choice, select, admin {admin {name}} owner {owner {name}} other {user {name}}}.');
+
+      expect(response?.length, equals(3));
+      expect(response?.elementAt(0).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(0).type, equals(ElementType.literal));
+      expect(response?.elementAt(0).value, equals('The '));
+
+      expect(response?.elementAt(1).runtimeType, equals(SelectElement));
+      expect(response?.elementAt(1).type, equals(ElementType.select));
+      expect(response?.elementAt(1).value, equals('choice'));
+
+      var options = (response?.elementAt(1) as SelectElement).options;
+
+      expect(options.length, equals(3));
+
+      expect(options[0].name, equals('admin'));
+      expect(options[0].value.length, equals(2));
+      expect(options[0].value[0].runtimeType, equals(LiteralElement));
+      expect(options[0].value[0].type, equals(ElementType.literal));
+      expect(options[0].value[0].value, equals('admin '));
+      expect(options[0].value[1].runtimeType, equals(ArgumentElement));
+      expect(options[0].value[1].type, equals(ElementType.argument));
+      expect(options[0].value[1].value, equals('name'));
+
+      expect(options[1].name, equals('owner'));
+      expect(options[1].value.length, equals(2));
+      expect(options[1].value[0].runtimeType, equals(LiteralElement));
+      expect(options[1].value[0].type, equals(ElementType.literal));
+      expect(options[1].value[0].value, equals('owner '));
+      expect(options[1].value[1].runtimeType, equals(ArgumentElement));
+      expect(options[1].value[1].type, equals(ElementType.argument));
+      expect(options[1].value[1].value, equals('name'));
+
+      expect(options[2].name, equals('other'));
+      expect(options[2].value.length, equals(2));
+      expect(options[2].value[0].runtimeType, equals(LiteralElement));
+      expect(options[2].value[0].type, equals(ElementType.literal));
+      expect(options[2].value[0].value, equals('user '));
+      expect(options[2].value[1].runtimeType, equals(ArgumentElement));
+      expect(options[2].value[1].type, equals(ElementType.argument));
+      expect(options[2].value[1].value, equals('name'));
+
+      expect(response?.elementAt(2).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(2).type, equals(ElementType.literal));
+      expect(response?.elementAt(2).value, equals('.'));
+    });
+
+    test('Test compound message of argument and plural', () {
+      var response = IcuParser().parse(
+          '{name} has {count, plural, one {{count} apple} other {{count} apples}} in the bag.');
+
+      expect(response?.length, equals(4));
+      expect(response?.elementAt(0).runtimeType, equals(ArgumentElement));
+      expect(response?.elementAt(0).type, equals(ElementType.argument));
+      expect(response?.elementAt(0).value, equals('name'));
+
+      expect(response?.elementAt(1).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(1).type, equals(ElementType.literal));
+      expect(response?.elementAt(1).value, equals(' has '));
+
+      expect(response?.elementAt(2).runtimeType, equals(PluralElement));
+      expect(response?.elementAt(2).type, equals(ElementType.plural));
+      expect(response?.elementAt(2).value, equals('count'));
+
+      var options = (response?.elementAt(2) as PluralElement).options;
+
+      expect(options.length, equals(2));
+
+      expect(options[0].name, equals('one'));
+      expect(options[0].value.length, equals(2));
+      expect(options[0].value[0].runtimeType, equals(ArgumentElement));
+      expect(options[0].value[0].type, equals(ElementType.argument));
+      expect(options[0].value[0].value, equals('count'));
+      expect(options[0].value[1].runtimeType, equals(LiteralElement));
+      expect(options[0].value[1].type, equals(ElementType.literal));
+      expect(options[0].value[1].value, equals(' apple'));
+
+      expect(options[1].name, equals('other'));
+      expect(options[1].value.length, equals(2));
+      expect(options[1].value[0].runtimeType, equals(ArgumentElement));
+      expect(options[1].value[0].type, equals(ElementType.argument));
+      expect(options[1].value[0].value, equals('count'));
+      expect(options[1].value[1].runtimeType, equals(LiteralElement));
+      expect(options[1].value[1].type, equals(ElementType.literal));
+      expect(options[1].value[1].value, equals(' apples'));
+
+      expect(response?.elementAt(3).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(3).type, equals(ElementType.literal));
+      expect(response?.elementAt(3).value, equals(' in the bag.'));
+    });
+
+    test('Test compound message of argument and gender', () {
+      var response = IcuParser().parse(
+          'The {gender, select, male {Mr {name}} female {Mrs {name}} other {dear {name}}} has the {device}.');
+
+      expect(response?.length, equals(5));
+      expect(response?.elementAt(0).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(0).type, equals(ElementType.literal));
+      expect(response?.elementAt(0).value, equals('The '));
+
+      expect(response?.elementAt(1).runtimeType, equals(GenderElement));
+      expect(response?.elementAt(1).type, equals(ElementType.gender));
+      expect(response?.elementAt(1).value, equals('gender'));
+
+      var options = (response?.elementAt(1) as GenderElement).options;
+
+      expect(options.length, equals(3));
+
+      expect(options[0].name, equals('male'));
+      expect(options[0].value.length, equals(2));
+      expect(options[0].value[0].runtimeType, equals(LiteralElement));
+      expect(options[0].value[0].type, equals(ElementType.literal));
+      expect(options[0].value[0].value, equals('Mr '));
+      expect(options[0].value[1].runtimeType, equals(ArgumentElement));
+      expect(options[0].value[1].type, equals(ElementType.argument));
+      expect(options[0].value[1].value, equals('name'));
+
+      expect(options[1].name, equals('female'));
+      expect(options[1].value.length, equals(2));
+      expect(options[1].value[0].runtimeType, equals(LiteralElement));
+      expect(options[1].value[0].type, equals(ElementType.literal));
+      expect(options[1].value[0].value, equals('Mrs '));
+      expect(options[1].value[1].runtimeType, equals(ArgumentElement));
+      expect(options[1].value[1].type, equals(ElementType.argument));
+      expect(options[1].value[1].value, equals('name'));
+
+      expect(options[2].name, equals('other'));
+      expect(options[2].value.length, equals(2));
+      expect(options[2].value[0].runtimeType, equals(LiteralElement));
+      expect(options[2].value[0].type, equals(ElementType.literal));
+      expect(options[2].value[0].value, equals('dear '));
+      expect(options[2].value[1].runtimeType, equals(ArgumentElement));
+      expect(options[2].value[1].type, equals(ElementType.argument));
+      expect(options[2].value[1].value, equals('name'));
+
+      expect(response?.elementAt(2).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(2).type, equals(ElementType.literal));
+      expect(response?.elementAt(2).value, equals(' has the '));
+
+      expect(response?.elementAt(3).runtimeType, equals(ArgumentElement));
+      expect(response?.elementAt(3).type, equals(ElementType.argument));
+      expect(response?.elementAt(3).value, equals('device'));
+
+      expect(response?.elementAt(4).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(4).type, equals(ElementType.literal));
+      expect(response?.elementAt(4).value, equals('.'));
+    });
+
+    test('Test compound message of argument and select', () {
+      var response = IcuParser().parse(
+          'The one {choice, select, coffee {{name} coffee} tea {{name} tea} other {{name} drink}} please for the {client}.');
+
+      expect(response?.length, equals(5));
+      expect(response?.elementAt(0).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(0).type, equals(ElementType.literal));
+      expect(response?.elementAt(0).value, equals('The one '));
+
+      expect(response?.elementAt(1).runtimeType, equals(SelectElement));
+      expect(response?.elementAt(1).type, equals(ElementType.select));
+      expect(response?.elementAt(1).value, equals('choice'));
+
+      var options = (response?.elementAt(1) as SelectElement).options;
+
+      expect(options.length, equals(3));
+
+      expect(options[0].name, equals('coffee'));
+      expect(options[0].value.length, equals(2));
+      expect(options[0].value[0].runtimeType, equals(ArgumentElement));
+      expect(options[0].value[0].type, equals(ElementType.argument));
+      expect(options[0].value[0].value, equals('name'));
+      expect(options[0].value[1].runtimeType, equals(LiteralElement));
+      expect(options[0].value[1].type, equals(ElementType.literal));
+      expect(options[0].value[1].value, equals(' coffee'));
+
+      expect(options[1].name, equals('tea'));
+      expect(options[1].value.length, equals(2));
+      expect(options[1].value[0].runtimeType, equals(ArgumentElement));
+      expect(options[1].value[0].type, equals(ElementType.argument));
+      expect(options[1].value[0].value, equals('name'));
+      expect(options[1].value[1].runtimeType, equals(LiteralElement));
+      expect(options[1].value[1].type, equals(ElementType.literal));
+      expect(options[1].value[1].value, equals(' tea'));
+
+      expect(options[2].name, equals('other'));
+      expect(options[2].value.length, equals(2));
+      expect(options[2].value[0].runtimeType, equals(ArgumentElement));
+      expect(options[2].value[0].type, equals(ElementType.argument));
+      expect(options[2].value[0].value, equals('name'));
+      expect(options[2].value[1].runtimeType, equals(LiteralElement));
+      expect(options[2].value[1].type, equals(ElementType.literal));
+      expect(options[2].value[1].value, equals(' drink'));
+
+      expect(response?.elementAt(2).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(2).type, equals(ElementType.literal));
+      expect(response?.elementAt(2).value, equals(' please for the '));
+
+      expect(response?.elementAt(3).runtimeType, equals(ArgumentElement));
+      expect(response?.elementAt(3).type, equals(ElementType.argument));
+      expect(response?.elementAt(3).value, equals('client'));
+
+      expect(response?.elementAt(4).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(4).type, equals(ElementType.literal));
+      expect(response?.elementAt(4).value, equals('.'));
+    });
+
+    test('Test compound message of two plurals', () {
+      var response = IcuParser().parse(
+          '{count1, plural, one {{count1} apple} other {{count1} apples}} and {count2, plural, one {{count2} orange} other {{count2} oranges}}');
+
+      expect(response?.length, equals(3));
+      expect(response?.elementAt(0).runtimeType, equals(PluralElement));
+      expect(response?.elementAt(0).type, equals(ElementType.plural));
+      expect(response?.elementAt(0).value, equals('count1'));
+
+      var options1 = (response?.elementAt(0) as PluralElement).options;
+
+      expect(options1.length, equals(2));
+
+      expect(options1[0].name, equals('one'));
+      expect(options1[0].value.length, equals(2));
+      expect(options1[0].value[0].runtimeType, equals(ArgumentElement));
+      expect(options1[0].value[0].type, equals(ElementType.argument));
+      expect(options1[0].value[0].value, equals('count1'));
+      expect(options1[0].value[1].runtimeType, equals(LiteralElement));
+      expect(options1[0].value[1].type, equals(ElementType.literal));
+      expect(options1[0].value[1].value, equals(' apple'));
+
+      expect(options1[1].name, equals('other'));
+      expect(options1[1].value.length, equals(2));
+      expect(options1[1].value[0].runtimeType, equals(ArgumentElement));
+      expect(options1[1].value[0].type, equals(ElementType.argument));
+      expect(options1[1].value[0].value, equals('count1'));
+      expect(options1[1].value[1].runtimeType, equals(LiteralElement));
+      expect(options1[1].value[1].type, equals(ElementType.literal));
+      expect(options1[1].value[1].value, equals(' apples'));
+
+      expect(response?.elementAt(1).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(1).type, equals(ElementType.literal));
+      expect(response?.elementAt(1).value, equals(' and '));
+
+      expect(response?.elementAt(2).runtimeType, equals(PluralElement));
+      expect(response?.elementAt(2).type, equals(ElementType.plural));
+      expect(response?.elementAt(2).value, equals('count2'));
+
+      var options2 = (response?.elementAt(2) as PluralElement).options;
+
+      expect(options2.length, equals(2));
+
+      expect(options2[0].name, equals('one'));
+      expect(options2[0].value.length, equals(2));
+      expect(options2[0].value[0].runtimeType, equals(ArgumentElement));
+      expect(options2[0].value[0].type, equals(ElementType.argument));
+      expect(options2[0].value[0].value, equals('count2'));
+      expect(options2[0].value[1].runtimeType, equals(LiteralElement));
+      expect(options2[0].value[1].type, equals(ElementType.literal));
+      expect(options2[0].value[1].value, equals(' orange'));
+
+      expect(options2[1].name, equals('other'));
+      expect(options2[1].value.length, equals(2));
+      expect(options2[1].value[0].runtimeType, equals(ArgumentElement));
+      expect(options2[1].value[0].type, equals(ElementType.argument));
+      expect(options2[1].value[0].value, equals('count2'));
+      expect(options2[1].value[1].runtimeType, equals(LiteralElement));
+      expect(options2[1].value[1].type, equals(ElementType.literal));
+      expect(options2[1].value[1].value, equals(' oranges'));
+    });
+
+    test('Test compound message of two genders', () {
+      var response = IcuParser().parse(
+          '{gender1, select, male {Mr {name}} female {Mrs {name}} other {dear {name}}} and {gender2, select, male {his} female {her} other {its}} cat');
+
+      expect(response?.length, equals(4));
+      expect(response?.elementAt(0).runtimeType, equals(GenderElement));
+      expect(response?.elementAt(0).type, equals(ElementType.gender));
+      expect(response?.elementAt(0).value, equals('gender1'));
+
+      var options1 = (response?.elementAt(0) as GenderElement).options;
+
+      expect(options1.length, equals(3));
+
+      expect(options1[0].name, equals('male'));
+      expect(options1[0].value.length, equals(2));
+      expect(options1[0].value[0].runtimeType, equals(LiteralElement));
+      expect(options1[0].value[0].type, equals(ElementType.literal));
+      expect(options1[0].value[0].value, equals('Mr '));
+      expect(options1[0].value[1].runtimeType, equals(ArgumentElement));
+      expect(options1[0].value[1].type, equals(ElementType.argument));
+      expect(options1[0].value[1].value, equals('name'));
+
+      expect(options1[1].name, equals('female'));
+      expect(options1[1].value.length, equals(2));
+      expect(options1[1].value[0].runtimeType, equals(LiteralElement));
+      expect(options1[1].value[0].type, equals(ElementType.literal));
+      expect(options1[1].value[0].value, equals('Mrs '));
+      expect(options1[1].value[1].runtimeType, equals(ArgumentElement));
+      expect(options1[1].value[1].type, equals(ElementType.argument));
+      expect(options1[1].value[1].value, equals('name'));
+
+      expect(options1[2].name, equals('other'));
+      expect(options1[2].value.length, equals(2));
+      expect(options1[2].value[0].runtimeType, equals(LiteralElement));
+      expect(options1[2].value[0].type, equals(ElementType.literal));
+      expect(options1[2].value[0].value, equals('dear '));
+      expect(options1[2].value[1].runtimeType, equals(ArgumentElement));
+      expect(options1[2].value[1].type, equals(ElementType.argument));
+      expect(options1[2].value[1].value, equals('name'));
+
+      expect(response?.elementAt(1).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(1).type, equals(ElementType.literal));
+      expect(response?.elementAt(1).value, equals(' and '));
+
+      expect(response?.elementAt(2).runtimeType, equals(GenderElement));
+      expect(response?.elementAt(2).type, equals(ElementType.gender));
+      expect(response?.elementAt(2).value, equals('gender2'));
+
+      var options2 = (response?.elementAt(2) as GenderElement).options;
+
+      expect(options2.length, equals(3));
+
+      expect(options2[0].name, equals('male'));
+      expect(options2[0].value.length, equals(1));
+      expect(options2[0].value[0].runtimeType, equals(LiteralElement));
+      expect(options2[0].value[0].type, equals(ElementType.literal));
+      expect(options2[0].value[0].value, equals('his'));
+
+      expect(options2[1].name, equals('female'));
+      expect(options2[1].value.length, equals(1));
+      expect(options2[1].value[0].runtimeType, equals(LiteralElement));
+      expect(options2[1].value[0].type, equals(ElementType.literal));
+      expect(options2[1].value[0].value, equals('her'));
+
+      expect(options2[2].name, equals('other'));
+      expect(options2[2].value.length, equals(1));
+      expect(options2[2].value[0].runtimeType, equals(LiteralElement));
+      expect(options2[2].value[0].type, equals(ElementType.literal));
+      expect(options2[2].value[0].value, equals('its'));
+
+      expect(response?.elementAt(3).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(3).type, equals(ElementType.literal));
+      expect(response?.elementAt(3).value, equals(' cat'));
+    });
+
+    test('Test compound message of two selects', () {
+      var response = IcuParser().parse(
+          '{choice1, select, admin {admin {name}} owner {owner {name}} other {user {name}}} with {choice2, select, IELTS {IELTS level} TOEFL {TOEFL level} other {Academic level}} of English');
+
+      expect(response?.length, equals(4));
+      expect(response?.elementAt(0).runtimeType, equals(SelectElement));
+      expect(response?.elementAt(0).type, equals(ElementType.select));
+      expect(response?.elementAt(0).value, equals('choice1'));
+
+      var options1 = (response?.elementAt(0) as SelectElement).options;
+
+      expect(options1.length, equals(3));
+
+      expect(options1[0].name, equals('admin'));
+      expect(options1[0].value.length, equals(2));
+      expect(options1[0].value[0].runtimeType, equals(LiteralElement));
+      expect(options1[0].value[0].type, equals(ElementType.literal));
+      expect(options1[0].value[0].value, equals('admin '));
+      expect(options1[0].value[1].runtimeType, equals(ArgumentElement));
+      expect(options1[0].value[1].type, equals(ElementType.argument));
+      expect(options1[0].value[1].value, equals('name'));
+
+      expect(options1[1].name, equals('owner'));
+      expect(options1[1].value.length, equals(2));
+      expect(options1[1].value[0].runtimeType, equals(LiteralElement));
+      expect(options1[1].value[0].type, equals(ElementType.literal));
+      expect(options1[1].value[0].value, equals('owner '));
+      expect(options1[1].value[1].runtimeType, equals(ArgumentElement));
+      expect(options1[1].value[1].type, equals(ElementType.argument));
+      expect(options1[1].value[1].value, equals('name'));
+
+      expect(options1[2].name, equals('other'));
+      expect(options1[2].value.length, equals(2));
+      expect(options1[2].value[0].runtimeType, equals(LiteralElement));
+      expect(options1[2].value[0].type, equals(ElementType.literal));
+      expect(options1[2].value[0].value, equals('user '));
+      expect(options1[2].value[1].runtimeType, equals(ArgumentElement));
+      expect(options1[2].value[1].type, equals(ElementType.argument));
+      expect(options1[2].value[1].value, equals('name'));
+
+      expect(response?.elementAt(1).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(1).type, equals(ElementType.literal));
+      expect(response?.elementAt(1).value, equals(' with '));
+
+      expect(response?.elementAt(2).runtimeType, equals(SelectElement));
+      expect(response?.elementAt(2).type, equals(ElementType.select));
+      expect(response?.elementAt(2).value, equals('choice2'));
+
+      var options2 = (response?.elementAt(2) as SelectElement).options;
+
+      expect(options2.length, equals(3));
+
+      expect(options2[0].name, equals('IELTS'));
+      expect(options2[0].value.length, equals(1));
+      expect(options2[0].value[0].runtimeType, equals(LiteralElement));
+      expect(options2[0].value[0].type, equals(ElementType.literal));
+      expect(options2[0].value[0].value, equals('IELTS level'));
+
+      expect(options2[1].name, equals('TOEFL'));
+      expect(options2[1].value.length, equals(1));
+      expect(options2[1].value[0].runtimeType, equals(LiteralElement));
+      expect(options2[1].value[0].type, equals(ElementType.literal));
+      expect(options2[1].value[0].value, equals('TOEFL level'));
+
+      expect(options2[2].name, equals('other'));
+      expect(options2[2].value.length, equals(1));
+      expect(options2[2].value[0].runtimeType, equals(LiteralElement));
+      expect(options2[2].value[0].type, equals(ElementType.literal));
+      expect(options2[2].value[0].value, equals('Academic level'));
+
+      expect(response?.elementAt(3).runtimeType, equals(LiteralElement));
+      expect(response?.elementAt(3).type, equals(ElementType.literal));
+      expect(response?.elementAt(3).value, equals(' of English'));
+    });
+  });
 }


### PR DESCRIPTION
Allows to have messages which are containing a plural, gender or select expression besides other parts. This allows to have messages like:

```json
{
  "sendMessageConfirm": "Are you sure that you want to send {count, plural, =1{one message} other{{count} messages}}?",
  "messageResponse": "{name} has sent you a message. Do you want to answer {gender, select, female{her} male{him} other{them}}?"
}
```

This makes it also more conform ti the ICU standard.