### PR TITLE
Feature/ignore avoid_catches_without_on_clauses always_use_package_imports in generated code

### DIFF
--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -18,6 +18,7 @@ import 'intl/messages_all.dart';
 // ignore_for_file: non_constant_identifier_names, lines_longer_than_80_chars
 // ignore_for_file: join_return_with_assignment, prefer_final_in_for_each
 // ignore_for_file: avoid_redundant_argument_values, avoid_escaping_inner_quotes
+// ignore_for_file: always_use_package_imports
 
 class $className {
   $className();

--- a/lib/src/intl_translation/generate_localized.dart
+++ b/lib/src/intl_translation/generate_localized.dart
@@ -202,7 +202,7 @@ class MessageGeneration {
 // ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
 // ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
 // ignore_for_file:unused_import, file_names, avoid_escaping_inner_quotes
-// ignore_for_file: avoid_catches_without_on_clauses, always_use_package_imports
+// ignore_for_file: always_use_package_imports
 
 import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';

--- a/lib/src/intl_translation/generate_localized.dart
+++ b/lib/src/intl_translation/generate_localized.dart
@@ -202,6 +202,7 @@ class MessageGeneration {
 // ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
 // ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
 // ignore_for_file:unused_import, file_names, avoid_escaping_inner_quotes
+// ignore_for_file: avoid_catches_without_on_clauses, always_use_package_imports
 
 import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';
@@ -284,6 +285,7 @@ class MessageLookup extends MessageLookupByLibrary {
 // ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
 // ignore_for_file:argument_type_not_assignable, invalid_assignment
 // ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
+// ignore_for_file: avoid_catches_without_on_clauses, always_use_package_imports
 // ignore_for_file:comment_references
 
 import 'dart:async';

--- a/lib/src/intl_translation/generate_localized.dart
+++ b/lib/src/intl_translation/generate_localized.dart
@@ -202,7 +202,6 @@ class MessageGeneration {
 // ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
 // ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
 // ignore_for_file:unused_import, file_names, avoid_escaping_inner_quotes
-// ignore_for_file: always_use_package_imports
 
 import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';


### PR DESCRIPTION
A simple PR which ignores [always_use_package_imports](https://dart-lang.github.io/linter/lints/always_use_package_imports.html) in `intl/messages_all.dart` and `l10n.dart`, and [avoid_catches_without_on_clauses](https://dart-lang.github.io/linter/lints/avoid_catches_without_on_clauses.html) in `messages_all.dart`.