### PR TITLE
support reloading messages when hot-reload

### DIFF
--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -29,8 +29,23 @@ class $className {
     return _current!;
   }
 
-  static const AppLocalizationDelegate delegate =
-    AppLocalizationDelegate();
+  static Future<void> reload() async {
+    reloadMessages();
+  }
+
+  static String get _hash => '${DateTime.now().hashCode}';
+  static String? _lastHash;
+
+  static AppLocalizationDelegate get delegate {
+    assert(() {
+      if (_lastHash != null && _lastHash != _hash) {
+        reloadMessages();
+      }
+      _lastHash = _hash;
+      return true;
+    }());
+    return const AppLocalizationDelegate();
+  }
 
   static Future<$className> load(Locale locale) {
     final name = (locale.countryCode?.isEmpty ?? false) ? locale.languageCode : locale.toString();

--- a/lib/src/intl_translation/generate_localized.dart
+++ b/lib/src/intl_translation/generate_localized.dart
@@ -254,7 +254,7 @@ class MessageLookup extends MessageLookupByLibrary {
     }
     output.write('\n');
     output.write('typedef Future<dynamic> LibraryLoader();\n');
-    output.write('Map<String, LibraryLoader> _deferredLibraries = {\n');
+    output.write('Map<String, LibraryLoader> get _deferredLibraries => {\n');
     for (var rawLocale in allLocales) {
       var locale = Intl.canonicalizedLocale(rawLocale);
       var loadOperation = (useDeferredLoading)
@@ -263,6 +263,22 @@ class MessageLookup extends MessageLookupByLibrary {
       output.write(loadOperation);
     }
     output.write('};\n');
+
+    output.write("""\n
+Future<void> reloadMessages() async {
+  for (final lib in _deferredLibraries.values) {
+    await lib();
+  }
+""");
+    for (var rawLocale in allLocales) {
+      var locale = Intl.canonicalizedLocale(rawLocale);
+      var _libName = libraryName(locale);
+      output.write('  $_libName.messages.messages.clear();\n');
+      output.write(
+          '  $_libName.messages.messages.addAll($_libName.MessageLookup().messages);\n');
+    }
+    output.write('}\n');
+
     output.write('\nMessageLookupByLibrary? _findExact(String localeName) {\n'
         '  switch (localeName) {\n');
     for (var rawLocale in allLocales) {


### PR DESCRIPTION
Auto reload l10n messages after code rebuilt then hot-reload, no additional code for user.

If you want to force reload messages:
```dart
import './path/to/messages_all.dart';

// somewhere you need
await reloadMessages();
```

## Related issue
- #56 


## Existing issues
- You may need to hot-reload or wait building widget once more to take effect on already created widgets