### PR TITLE
Intl.plural: first argument as num

### DIFF
--- a/lib/src/generator/label.dart
+++ b/lib/src/generator/label.dart
@@ -693,7 +693,13 @@ class Label {
               ElementType.select
             ].contains(item.type))
         .forEach((item) {
-      args.add(Argument('Object', item.value, null));
+      args.add(
+        Argument(
+          (item.type == ElementType.plural) ? 'num' : 'Object',
+          item.value,
+          null,
+        ),
+      );
     });
 
     return args;
@@ -1020,7 +1026,7 @@ class Label {
       }
     });
 
-    return 'Intl.plural(${element.value}, ${options.join(', ')})';
+    return 'Intl.plural(${element.value} as num, ${options.join(', ')})';
   }
 
   String _generateGenderMessage(GenderElement element, List<Argument> args) {

--- a/lib/src/intl_translation/src/intl_message.dart
+++ b/lib/src/intl_translation/src/intl_message.dart
@@ -786,6 +786,9 @@ abstract class SubMessage extends ComplexMessage {
     out.write(dartMessageName);
     out.write('(');
     out.write(mainArgument);
+    if (dartMessageName == 'Intl.plural') {
+      out.write(' as num');
+    }
     var args = codeAttributeNames.where((attribute) => this[attribute] != null);
     args.fold(
         out,


### PR DESCRIPTION
Fix error "The argument type 'dynamic' can't be assigned to the parameter type 'num'. dart(argument_type_not_assignable)" in generated code for Intl.plural calls 
`static String m0(count) =>
      "${Intl.plural(count, one:`