### PR TITLE
Escape dot character `.` when generating getter

### DIFF
--- a/lib/src/generator/label.dart
+++ b/lib/src/generator/label.dart
@@ -1184,7 +1184,7 @@ class Label {
         .replaceAll('\f', '\\f')
         .replaceAll('\'', '\\\'')
         .replaceAll('\$', '\\\$')
-        .replaceAll('\.', '');
+        .replaceAll('.', '');
   }
 
   String _escapeDartDoc(String value) {

--- a/lib/src/generator/label.dart
+++ b/lib/src/generator/label.dart
@@ -1184,7 +1184,7 @@ class Label {
         .replaceAll('\f', '\\f')
         .replaceAll('\'', '\\\'')
         .replaceAll('\$', '\\\$')
-        .replaceAll('.', '');
+        .replaceAll('\.', '');
   }
 
   String _escapeDartDoc(String value) {

--- a/lib/src/generator/label.dart
+++ b/lib/src/generator/label.dart
@@ -1183,7 +1183,8 @@ class Label {
         .replaceAll('\b', '\\b')
         .replaceAll('\f', '\\f')
         .replaceAll('\'', '\\\'')
-        .replaceAll('\$', '\\\$');
+        .replaceAll('\$', '\\\$')
+        .replaceAll('.', '');
   }
 
   String _escapeDartDoc(String value) {

--- a/lib/src/generator/label.dart
+++ b/lib/src/generator/label.dart
@@ -287,6 +287,7 @@ class Label {
   /// Generates label getter.
   String generateDartGetter() {
     try {
+      var name = _escape(this.name);
       var content = _escape(this.content);
       var description = _escape(this.description ?? '');
 


### PR DESCRIPTION
Sometimes we get keys containing dot `.`  character and we cannot control removing the dot.

This commit solves this issue by replacing dot character `'.'` with empty string `''`.