### PR TITLE
Add generated language code enum

### DIFF
--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -19,7 +19,7 @@ import 'intl/messages_all.dart';
 // ignore_for_file: join_return_with_assignment, prefer_final_in_for_each
 // ignore_for_file: avoid_redundant_argument_values, avoid_escaping_inner_quotes
 
-enum SupportedLanguageCodes { ${locales.map((locale) => _generateLanguageCode(locale)).join(",\n")} }
+enum SupportedLanguageCode { ${locales.map((locale) => _generateLanguageCode(locale)).join(",\n")} }
 
 class $className {
   $className();

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -19,6 +19,8 @@ import 'intl/messages_all.dart';
 // ignore_for_file: join_return_with_assignment, prefer_final_in_for_each
 // ignore_for_file: avoid_redundant_argument_values, avoid_escaping_inner_quotes
 
+enum SupportedLanguageCodes { ${locales.map((locale) => _generateLanguageCode(locale)).join(",\n")} }
+
 class $className {
   $className();
 
@@ -84,6 +86,12 @@ ${locales.map((locale) => _generateLocale(locale)).join("\n")}
 }
 """
       .trim();
+}
+
+String _generateLanguageCode(String locale) {
+  var parts = locale.split('_');
+
+  return parts[0];
 }
 
 String _generateLocale(String locale) {


### PR DESCRIPTION
We needed the possible options to do something like: 

```
    // TODO fetch selected language 
    const selectedValue = SupportedLanguageCodes.de;

    final language = switch (selectedValue) {
      SupportedLanguageCodes.de => "name_de",
      SupportedLanguageCodes.en => "name_en"
    };
    
    mapController.setLanguage(language);
```