### PR TITLE
Update http dependency constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,14 +4,14 @@ version: 2.8.2
 homepage: https://github.com/localizely/intl_utils
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   analyzer: ^5.0.0
   archive: ^3.0.0
   args: ^2.0.0
   dart_style: ^2.0.0
-  http: ^0.13.0
+  http: ">=0.13.0 <2.0.0"
   intl: ">=0.17.0 <0.19.0"
   path: ^1.8.0
   petitparser: ">=4.0.0 <6.0.0"


### PR DESCRIPTION
The `http` dependency could be updated so that people using Dart 3 could use `http >= 1.0`