### PR TITLE
Update `analyzer` package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  analyzer: ^5.0.0
+  analyzer: ^6.0.0
   archive: ^3.0.0
   args: ^2.0.0
   dart_style: ^2.0.0


### PR DESCRIPTION
This was causing version resolution errors:
```console
Because no versions of intl_utils match >2.8.4 <3.0.0 and intl_utils 2.8.4 depends on analyzer ^5.0.0, intl_utils ^2.8.4 requires analyzer ^5.0.0.
And because freezed >=2.4.2 depends on analyzer ^6.0.0, intl_utils ^2.8.4 is incompatible with freezed >=2.4.2.
So, because craftos depends on both freezed ^2.4.2 and intl_utils ^2.8.4, version solving failed.
```