### PR TITLE
Update intl support and fix deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the "flutter-intl" extension will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.8.7 - Unreleased
+
+- Update `intl` dependency
+
 ## 2.8.6 - 2023-11-22
 
 - Update `analyzer` dependency

--- a/lib/src/parser/icu_parser.dart
+++ b/lib/src/parser/icu_parser.dart
@@ -150,7 +150,7 @@ class IcuParser {
         .map((result) =>
             List<BaseElement>.from(result is List ? result : [result]))
         .parse(message);
-    return parsed.isSuccess ? parsed.value : null;
+    return parsed is Success ? parsed.value : null;
   }
 
   IcuParser() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: intl_utils
 description: intl_utils is a dart library that generates Dart localization code from ARB file. Generated code relies on Intl library.
-version: 2.8.6
+version: 2.8.7
 homepage: https://github.com/localizely/intl_utils
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
   args: ^2.0.0
   dart_style: ^2.0.0
   http: ">=0.13.0 <2.0.0"
-  intl: ">=0.17.0 <0.19.0"
+  intl: ">=0.17.0 <0.20.0"
   path: ^1.8.0
   petitparser: ">=4.0.0 <7.0.0"
   yaml: ^3.0.0


### PR DESCRIPTION
Adds support for intl v0.19.0 and fixes a deprecation warning from petitparser v6. The deprecation fix is compatible with petitparser v4, the minimum version supported by `intl_utils`.