### PR TITLE
Added ability to find and clean unused translation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,42 @@ To generate boilerplate code for localization, run the `generate` program inside
 This will produce files inside `lib/generated` directory.
 You can also change the output folder from `lib/generated` to a custom directory by adding the `output_dir` line in your `pubspec.yaml` file.
 
+### Find and clean unused translation keys
+
+You can now find and clean unused translation keys in your project. This helps keep your localization files tidy and removes any keys that are no longer used in your code.
+
+#### Find unused keys
+
+To find unused keys and print the count:
+
+      flutter pub run intl_utils:unused
+
+This will simply print the number of unused keys found.
+
+#### Save unused keys to .txt file
+
+To find unused keys and save them to a file:
+
+      flutter pub run intl_utils:unused --save
+
+This will create a file `unused_keys.txt` containing the unused keys.
+
+#### Clean unused keys
+
+To clean unused keys from your .arb files and regenerate intl boilerplate code for localization:
+
+      flutter pub run intl_utils:unused --clean
+
+By default, this will prompt for confirmation before cleaning. You can force the cleaning without confirmation using:
+
+      flutter pub run intl_utils:unused --force-clean
+
+#### Skip regeneration
+
+If you do not want to regenerate the localization files after cleaning, use:
+
+      flutter pub run intl_utils:unused --clean --no-regenerate
+
 ### Integration with Localizely
 
 #### Upload main ARB file

--- a/bin/unused.dart
+++ b/bin/unused.dart
@@ -1,0 +1,26 @@
+library intl_utils;
+
+import 'package:intl_utils/src/unused/unused.dart';
+import 'package:intl_utils/src/unused/unused_exception.dart';
+import 'package:intl_utils/src/utils/utils.dart';
+
+Future<void> main(List<String> args) async {
+  try {
+    var unused = Unused();
+
+    final saveToFile = args.contains('--save');
+    final clean = args.contains('--clean');
+    final forceClean = args.contains('--force-clean');
+    final noRegenerate = args.contains('--no-regenerate');
+    await unused.findUnusedAsync(
+      saveToFile: saveToFile,
+      clean: clean,
+      forceClean: forceClean,
+      noRegenerate: noRegenerate,
+    );
+  } on UnusedException catch (e) {
+    exitWithError(e.message);
+  } catch (e) {
+    exitWithError('Failed to find unused keys.\n$e');
+  }
+}

--- a/lib/src/unused/key_visitor.dart
+++ b/lib/src/unused/key_visitor.dart
@@ -1,0 +1,27 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+class KeyVisitor extends RecursiveAstVisitor<void> {
+  final String className;
+  bool insideClass = false;
+  final keys = <String>[];
+
+  KeyVisitor(this.className);
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    if (node.name.lexeme == className) {
+      insideClass = true;
+      super.visitClassDeclaration(node);
+      insideClass = false;
+    }
+  }
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    if (insideClass && !node.isStatic) {
+      keys.add(node.name.lexeme);
+    }
+    super.visitMethodDeclaration(node);
+  }
+}

--- a/lib/src/unused/unused.dart
+++ b/lib/src/unused/unused.dart
@@ -1,0 +1,197 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
+
+import '../config/pubspec_config.dart';
+import '../constants/constants.dart';
+import '../generator/generator.dart';
+import '../utils/file_utils.dart';
+import '../utils/utils.dart';
+import 'key_visitor.dart';
+import 'unused_exception.dart';
+
+/// Class for finding unused keys in the localization files.
+/// This class analyzes the specified Dart class for keys and checks their usage across the project.
+class Unused {
+  late String _className;
+  late String _outputDir;
+  late String _arbDir;
+
+  /// Creates a new instance with configuration from the 'pubspec.yaml' file.
+  Unused() {
+    final pubspecConfig = PubspecConfig();
+
+    _className = defaultClassName;
+    if (pubspecConfig.className != null) {
+      if (isValidClassName(pubspecConfig.className!)) {
+        _className = pubspecConfig.className!;
+      } else {
+        warning(
+            "Config parameter 'class_name' requires a valid 'UpperCamelCase' value.");
+      }
+    }
+
+    _outputDir = defaultOutputDir;
+    if (pubspecConfig.outputDir != null) {
+      if (isValidPath(pubspecConfig.outputDir!)) {
+        _outputDir = pubspecConfig.outputDir!;
+      } else {
+        warning(
+            "Config parameter 'output_dir' requires a valid path value (e.g., 'lib', 'res/', 'lib\\l10n').");
+      }
+    }
+
+    _arbDir = defaultArbDir;
+    if (pubspecConfig.arbDir != null) {
+      if (isValidPath(pubspecConfig.arbDir!)) {
+        _arbDir = pubspecConfig.arbDir!;
+      } else {
+        warning(
+            "Config parameter 'arb_dir' requires valid path value (e.g. 'lib', 'res/', 'lib\\l10n').");
+      }
+    }
+  }
+
+  /// Finds unused keys in the specified Dart class.
+  /// Analyzes all Dart files in the project to determine which keys are not used.
+  Future<void> findUnusedAsync({
+    bool saveToFile = false,
+    bool clean = false,
+    bool forceClean = false,
+    bool noRegenerate = false,
+  }) async {
+    final l10nDartFilePath = getL10nDartFilePath(_outputDir);
+
+    if (!File(l10nDartFilePath).existsSync()) {
+      throw UnusedException('The file $l10nDartFilePath does not exist.');
+    }
+
+    final keys = _getKeys(l10nDartFilePath, _className);
+    final allFiles = _getDartFiles();
+
+    final allCodeBuffer = StringBuffer();
+    int processedFiles = 0;
+    final totalFiles = allFiles.length;
+
+    for (final file in allFiles) {
+      allCodeBuffer.write(File(file.path).readAsStringSync());
+      processedFiles++;
+      _showProgress(processedFiles, totalFiles, 'Reading project files');
+    }
+
+    final allCode = allCodeBuffer.toString();
+
+    processedFiles = 0;
+    final unusedKeys = <String>[];
+    for (final key in keys) {
+      if (!allCode.contains('.$key')) {
+        unusedKeys.add(key);
+      }
+      processedFiles++;
+      _showProgress(processedFiles, keys.length, 'Checking keys');
+    }
+
+    info(
+        'Found ${unusedKeys.length} unused keys out of ${keys.length} in ${allFiles.length} files');
+
+    if (saveToFile) {
+      await _saveUnusedKeysToFile(unusedKeys);
+    }
+
+    if (forceClean) {
+      await _cleanUnusedKeys(unusedKeys);
+      if (!noRegenerate) {
+        await _regenerateFiles();
+      }
+    } else if (clean) {
+      await _confirmAndCleanUnusedKeys(unusedKeys, noRegenerate);
+    }
+  }
+
+  List<String> _getKeys(String filePath, String className) {
+    final file = File(filePath);
+    final code = file.readAsStringSync();
+    final result = parseString(content: code);
+
+    final visitor = KeyVisitor(className);
+    result.unit.visitChildren(visitor);
+
+    return visitor.keys;
+  }
+
+  List<FileSystemEntity> _getDartFiles() {
+    final globPattern = Glob("lib/**.dart");
+    return globPattern.listSync(followLinks: false);
+  }
+
+  Future<void> _saveUnusedKeysToFile(List<String> unusedKeys) async {
+    final file = File('unused_keys.txt');
+    final sink = file.openWrite();
+    for (final key in unusedKeys) {
+      sink.writeln(key);
+    }
+    await sink.close();
+  }
+
+  Future<void> _confirmAndCleanUnusedKeys(
+    List<String> unusedKeys,
+    bool noRegenerate,
+  ) async {
+    stdout.writeln(
+        'This operation will remove ${unusedKeys.length} unused keys from the original .arb files.');
+    stdout.write('Do you want to proceed? (y/n): ');
+    final response = stdin.readLineSync();
+    if (response?.toLowerCase() == 'y') {
+      await _cleanUnusedKeys(unusedKeys);
+      if (!noRegenerate) {
+        await _regenerateFiles();
+      }
+    } else {
+      stdout.writeln('Operation cancelled.');
+    }
+  }
+
+  Future<void> _cleanUnusedKeys(List<String> unusedKeys) async {
+    final arbFiles = getArbFiles(_arbDir).map((file) => file.path).toList();
+    final jsonDecoder = JsonDecoder();
+    final jsonEncoder = JsonEncoder.withIndent('  ');
+
+    for (final arbFile in arbFiles) {
+      final file = File(arbFile);
+      final content = await file.readAsString();
+      final map = jsonDecoder.convert(content) as Map<String, dynamic>;
+
+      int removedKeysCount = 0;
+      for (final key in unusedKeys) {
+        if (map.containsKey(key)) {
+          map.remove(key);
+          map.remove('@$key'); // Remove associated metadata
+          removedKeysCount++;
+        }
+      }
+
+      if (removedKeysCount > 0) {
+        final updatedContent = jsonEncoder.convert(map);
+        await file.writeAsString(updatedContent);
+        info('Removed $removedKeysCount unused keys from ${file.path}');
+      }
+    }
+  }
+
+  Future<void> _regenerateFiles() async {
+    final generator = Generator();
+    await generator.generateAsync();
+    info('Regenerated localization files.');
+  }
+
+  void _showProgress(int current, int total, String phase) {
+    final progress = (current / total * 100).toStringAsFixed(1);
+    stdout.write('\r$phase: $progress% ($current/$total)');
+    if (current == total) {
+      stdout.writeln();
+    }
+  }
+}

--- a/lib/src/unused/unused.dart
+++ b/lib/src/unused/unused.dart
@@ -87,7 +87,14 @@ class Unused {
     processedFiles = 0;
     final unusedKeys = <String>[];
     for (final key in keys) {
-      if (!allCode.contains('.$key')) {
+      final regex = RegExp(
+          r'\b' +
+              _className +
+              r'\s*\.\s*(current|of\(.*?\))\s*\.\s*' +
+              key +
+              r'\b',
+          multiLine: true);
+      if (!regex.hasMatch(allCode)) {
         unusedKeys.add(key);
       }
       processedFiles++;

--- a/lib/src/unused/unused_exception.dart
+++ b/lib/src/unused/unused_exception.dart
@@ -1,0 +1,8 @@
+class UnusedException implements Exception {
+  final String message;
+
+  UnusedException(this.message);
+
+  @override
+  String toString() => 'UnusedException: $message';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   archive: ">=3.0.0 <5.0.0"
   args: ^2.0.0
   dart_style: ^3.0.0
+  glob: ^2.1.2
   http: ">=0.13.0 <2.0.0"
   intl: ">=0.17.0 <0.21.0"
   path: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   archive: ^3.0.0
   args: ^2.0.0
   dart_style: ^2.0.0
+  glob: ^2.1.2
   http: ">=0.13.0 <2.0.0"
   intl: ">=0.17.0 <0.20.0"
   path: ^1.8.0


### PR DESCRIPTION
This PR introduces the ability to find and clean unused translation keys in Dart projects.

- Added methods to identify and remove unused translation keys
- Support for saving unused keys to a file using `--save`
- Support for cleaning unused keys from .arb files with `--clean`
- Added a confirmation prompt before cleaning, with `--force-clean` to skip confirmation
- Option to skip regenerating files after cleaning with `--no-regenerate`
