### PR TITLE
Sort arbs after generating the code

### DIFF
--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -229,5 +229,5 @@ class _ArbKeyData {
   Object? value;
   Object? metadataValue;
 
-  _ArbKeyData({required this.key, this.value, this.metadataValue});
+  _ArbKeyData({required this.key});
 }

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import '../config/pubspec_config.dart';
 import '../constants/constants.dart';
@@ -78,6 +79,7 @@ class Generator {
     await _updateL10nDir();
     await _updateGeneratedDir();
     await _generateDartFiles();
+    await _sortKeysInArbFiles();
   }
 
   Future<void> _updateL10nDir() async {
@@ -171,4 +173,61 @@ class Generator {
     var helper = IntlTranslationHelper(_useDeferredLoading);
     helper.generateFromArb(outputDir, dartFiles, arbFiles);
   }
+
+  Future<void> _sortKeysInArbFiles() async {
+    var arbFiles = getArbFiles(_arbDir).whereType<File>();
+
+    await Future.wait(arbFiles.map((file) => _sortArbFile(file)));
+  }
+
+  Future<void> _sortArbFile(File file) async {
+    final src = file.readAsStringSync();
+    final data = jsonDecode(src);
+    if (data is! Map<String, dynamic>) return;
+
+    final Map<String, _ArbKeyData> groupedByKey = {};
+    for (final entry in data.entries) {
+      final String rawKey = entry.key;
+      final Object value = entry.value;
+
+      final isMetadata = rawKey.startsWith('@');
+      final key = isMetadata ? rawKey.substring(1) : rawKey;
+
+      if (!groupedByKey.containsKey(key)) {
+        groupedByKey[key] = _ArbKeyData(key: key);
+      }
+
+      if (isMetadata) {
+        groupedByKey[key]!.metadataValue = value;
+      } else {
+        groupedByKey[key]!.value = value;
+      }
+    }
+
+    final sortedKeys = groupedByKey.keys.toList();
+    sortedKeys.sort((a, b) => a.compareTo(b));
+
+    final Map<String, Object> sortedData = {};
+    for (final key in sortedKeys) {
+      final arbData = groupedByKey[key]!;
+      if (arbData.value != null) {
+        sortedData[key] = arbData.value!;
+      }
+      if (arbData.metadataValue != null) {
+        sortedData['@$key'] = arbData.metadataValue!;
+      }
+    }
+
+    final JsonEncoder encoder = JsonEncoder.withIndent('  ');
+    final sortedArb = encoder.convert(sortedData);
+    await file.writeAsString(sortedArb);
+  }
+}
+
+class _ArbKeyData {
+  final String key;
+  Object? value;
+  Object? metadataValue;
+
+  _ArbKeyData({required this.key, this.value, this.metadataValue});
 }

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -76,10 +76,10 @@ class Generator {
 
   /// Generates localization files.
   Future<void> generateAsync() async {
+    await _sortKeysInArbFiles();
     await _updateL10nDir();
     await _updateGeneratedDir();
     await _generateDartFiles();
-    await _sortKeysInArbFiles();
   }
 
   Future<void> _updateL10nDir() async {


### PR DESCRIPTION
In our workflow we have english as our base language. We add strings in the english .arb and then upload them to Localazy for translating. 

The issue comes when we download new translated strings from Localazy. These strings come alphabetically sorted, which messes with the git repository, sometimes causing merge conflicts with our different branches.

Sorting the strings every time we generate the dart code would fix this and make git usage easier.

If this is too breaking we could hide it behind a flag when generating the code.